### PR TITLE
fix: check attestation source and target

### DIFF
--- a/src/storage/clickhouse/clickhouse.types.ts
+++ b/src/storage/clickhouse/clickhouse.types.ts
@@ -54,8 +54,10 @@ export interface NOsProposesStats {
 export interface SlotAttestation {
   bits: boolean[];
   head: string;
-  target: string;
-  source: string;
+  target_root: string;
+  target_epoch: string;
+  source_root: string;
+  source_epoch: string;
   slot: string;
   committee_index: string;
 }


### PR DESCRIPTION
Because of the long finality, source may not equal prev epoch from attestation slot. We must take source epoch from attestation (`source.epoch`) and check its root