### PR TITLE
fix: bad cache

### DIFF
--- a/src/common/eth-providers/consensus-provider/block-cache/block-cache.service.ts
+++ b/src/common/eth-providers/consensus-provider/block-cache/block-cache.service.ts
@@ -53,4 +53,8 @@ export class BlockCacheService {
     }
     this.logger.debug(`Purged blocks cache count: ${purged}`);
   }
+
+  public clear() {
+    this.cache.clear();
+  }
 }

--- a/src/inspector/inspector.module.ts
+++ b/src/inspector/inspector.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 
 import { CriticalAlertsModule } from 'common/alertmanager/critical-alerts.module';
 import { EthProvidersModule } from 'common/eth-providers';
+import { BlockCacheModule } from 'common/eth-providers/consensus-provider/block-cache';
 import { RegistryModule } from 'common/validators-registry';
 import { DutyModule } from 'duty';
 import { ClickhouseModule } from 'storage/clickhouse';
@@ -9,7 +10,7 @@ import { ClickhouseModule } from 'storage/clickhouse';
 import { InspectorService } from './inspector.service';
 
 @Module({
-  imports: [EthProvidersModule, CriticalAlertsModule, ClickhouseModule, RegistryModule, DutyModule],
+  imports: [EthProvidersModule, BlockCacheModule, CriticalAlertsModule, ClickhouseModule, RegistryModule, DutyModule],
   providers: [InspectorService],
   exports: [InspectorService],
 })

--- a/src/inspector/inspector.service.ts
+++ b/src/inspector/inspector.service.ts
@@ -9,6 +9,8 @@ import { PrometheusService } from 'common/prometheus';
 import { DutyMetrics, DutyService } from 'duty';
 import { ClickhouseService } from 'storage';
 
+import { BlockCacheService } from '../common/eth-providers/consensus-provider/block-cache';
+
 @Injectable()
 export class InspectorService implements OnModuleInit {
   public latestProcessedEpoch = 0n;
@@ -20,6 +22,7 @@ export class InspectorService implements OnModuleInit {
     protected readonly storage: ClickhouseService,
     protected readonly prometheus: PrometheusService,
     protected readonly criticalAlerts: CriticalAlertsService,
+    protected readonly blockCacheService: BlockCacheService,
 
     protected readonly dutyService: DutyService,
     protected readonly dutyMetrics: DutyMetrics,
@@ -53,6 +56,8 @@ export class InspectorService implements OnModuleInit {
       } catch (e) {
         this.logger.error(`Error while processing and writing epoch`);
         this.logger.error(e as any);
+        // Remove the cache because there may be an error due to bad node responses
+        this.blockCacheService.clear();
         // We should make a gap before running new circle. This will avoid requests and logs spam
         await sleep(this.config.get('CHAIN_SLOT_TIME_SECONDS') * 1000);
       }


### PR DESCRIPTION
In some cases when node balancer gives us non-finalized responses, we throw error, but don't clear block info cache