### PR TITLE
fix: case when operator changes his name

### DIFF
--- a/src/common/alertmanager/alerts/BasicAlert.ts
+++ b/src/common/alertmanager/alerts/BasicAlert.ts
@@ -1,7 +1,6 @@
 import { ConfigService } from 'common/config';
+import { RegistrySourceOperator } from 'common/validators-registry';
 import { ClickhouseService } from 'storage';
-
-import { RegistrySourceOperator } from '../../validators-registry';
 
 export interface AlertRequestBody {
   startsAt: string;

--- a/src/common/alertmanager/alerts/BasicAlert.ts
+++ b/src/common/alertmanager/alerts/BasicAlert.ts
@@ -1,6 +1,8 @@
 import { ConfigService } from 'common/config';
 import { ClickhouseService } from 'storage';
 
+import { RegistrySourceOperator } from '../../validators-registry';
+
 export interface AlertRequestBody {
   startsAt: string;
   endsAt: string;
@@ -23,11 +25,13 @@ export abstract class Alert {
   protected sendTimestamp = 0;
   protected readonly config: ConfigService;
   protected readonly storage: ClickhouseService;
+  protected readonly operators: RegistrySourceOperator[];
 
-  protected constructor(name: string, config: ConfigService, storage: ClickhouseService) {
+  protected constructor(name: string, config: ConfigService, storage: ClickhouseService, operators: RegistrySourceOperator[]) {
     this.alertname = name;
     this.config = config;
     this.storage = storage;
+    this.operators = operators;
   }
 
   abstract alertRule(bySlot: bigint): Promise<AlertRuleResult>;

--- a/src/common/alertmanager/alerts/CriticalMissedAttestations.ts
+++ b/src/common/alertmanager/alerts/CriticalMissedAttestations.ts
@@ -4,24 +4,26 @@ import { sentAlerts } from 'common/alertmanager';
 import { ConfigService } from 'common/config';
 import { ClickhouseService } from 'storage';
 
+import { RegistrySourceOperator } from '../../validators-registry';
 import { Alert, AlertRequestBody, AlertRuleResult } from './BasicAlert';
 
 const VALIDATORS_WITH_MISSED_ATTESTATION_COUNT_THRESHOLD = 1 / 3;
 
 export class CriticalMissedAttestations extends Alert {
-  constructor(config: ConfigService, storage: ClickhouseService) {
-    super(CriticalMissedAttestations.name, config, storage);
+  constructor(config: ConfigService, storage: ClickhouseService, operators: RegistrySourceOperator[]) {
+    super(CriticalMissedAttestations.name, config, storage, operators);
   }
 
   async alertRule(epoch: bigint): Promise<AlertRuleResult> {
     const result: AlertRuleResult = {};
-    const operators = await this.storage.getUserNodeOperatorsStats(epoch);
+    const nosStats = await this.storage.getUserNodeOperatorsStats(epoch);
     const missedAttValidatorsCount = await this.storage.getValidatorCountWithMissedAttestationsLastNEpoch(epoch);
-    for (const operator of operators.filter((o) => o.active_ongoing > this.config.get('CRITICAL_ALERTS_MIN_VAL_COUNT'))) {
-      const missedAtt = missedAttValidatorsCount.find((a) => a.val_nos_name == operator.val_nos_name);
+    for (const noStats of nosStats.filter((o) => o.active_ongoing > this.config.get('CRITICAL_ALERTS_MIN_VAL_COUNT'))) {
+      const operator = this.operators.find((o) => +noStats.val_nos_id == o.index);
+      const missedAtt = missedAttValidatorsCount.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       if (!missedAtt) continue;
-      if (missedAtt.amount > operator.active_ongoing * VALIDATORS_WITH_MISSED_ATTESTATION_COUNT_THRESHOLD) {
-        result[operator.val_nos_name] = { ongoing: operator.active_ongoing, missedAtt: missedAtt.amount };
+      if (missedAtt.amount > noStats.active_ongoing * VALIDATORS_WITH_MISSED_ATTESTATION_COUNT_THRESHOLD) {
+        result[operator.name] = { ongoing: noStats.active_ongoing, missedAtt: missedAtt.amount };
       }
     }
     return result;

--- a/src/common/alertmanager/alerts/CriticalMissedAttestations.ts
+++ b/src/common/alertmanager/alerts/CriticalMissedAttestations.ts
@@ -2,9 +2,9 @@ import { join } from 'lodash';
 
 import { sentAlerts } from 'common/alertmanager';
 import { ConfigService } from 'common/config';
+import { RegistrySourceOperator } from 'common/validators-registry';
 import { ClickhouseService } from 'storage';
 
-import { RegistrySourceOperator } from '../../validators-registry';
 import { Alert, AlertRequestBody, AlertRuleResult } from './BasicAlert';
 
 const VALIDATORS_WITH_MISSED_ATTESTATION_COUNT_THRESHOLD = 1 / 3;

--- a/src/common/alertmanager/alerts/CriticalMissedProposes.ts
+++ b/src/common/alertmanager/alerts/CriticalMissedProposes.ts
@@ -2,9 +2,9 @@ import { join } from 'lodash';
 
 import { sentAlerts } from 'common/alertmanager';
 import { ConfigService } from 'common/config';
+import { RegistrySourceOperator } from 'common/validators-registry';
 import { ClickhouseService } from 'storage';
 
-import { RegistrySourceOperator } from '../../validators-registry';
 import { Alert, AlertRequestBody, AlertRuleResult } from './BasicAlert';
 
 const VALIDATORS_WITH_MISSED_PROPOSALS_COUNT_THRESHOLD = 1 / 3;

--- a/src/common/alertmanager/alerts/CriticalNegativeDelta.ts
+++ b/src/common/alertmanager/alerts/CriticalNegativeDelta.ts
@@ -4,22 +4,26 @@ import { sentAlerts } from 'common/alertmanager';
 import { ConfigService } from 'common/config';
 import { ClickhouseService } from 'storage';
 
+import { RegistrySourceOperator } from '../../validators-registry';
 import { Alert, AlertRequestBody, AlertRuleResult } from './BasicAlert';
 
+const VALIDATORS_WITH_NEGATIVE_DELTA_COUNT_THRESHOLD = 1 / 3;
+
 export class CriticalNegativeDelta extends Alert {
-  constructor(config: ConfigService, storage: ClickhouseService) {
-    super(CriticalNegativeDelta.name, config, storage);
+  constructor(config: ConfigService, storage: ClickhouseService, operators: RegistrySourceOperator[]) {
+    super(CriticalNegativeDelta.name, config, storage, operators);
   }
 
   async alertRule(epoch: bigint): Promise<AlertRuleResult> {
     const result: AlertRuleResult = {};
-    const operators = await this.storage.getUserNodeOperatorsStats(epoch);
+    const nosStats = await this.storage.getUserNodeOperatorsStats(epoch);
     const negativeValidatorsCount = await this.storage.getValidatorsCountWithNegativeDelta(epoch);
-    for (const operator of operators.filter((o) => o.active_ongoing > this.config.get('CRITICAL_ALERTS_MIN_VAL_COUNT'))) {
-      const negDelta = negativeValidatorsCount.find((a) => a.val_nos_name == operator.val_nos_name);
+    for (const noStats of nosStats.filter((o) => o.active_ongoing > this.config.get('CRITICAL_ALERTS_MIN_VAL_COUNT'))) {
+      const operator = this.operators.find((o) => +noStats.val_nos_id == o.index);
+      const negDelta = negativeValidatorsCount.find((a) => +a.val_nos_id == operator.index);
       if (!negDelta) continue;
-      if (negDelta.neg_count > operator.active_ongoing / 3) {
-        result[operator.val_nos_name] = { ongoing: operator.active_ongoing, negDelta: negDelta.neg_count };
+      if (negDelta.neg_count > noStats.active_ongoing * VALIDATORS_WITH_NEGATIVE_DELTA_COUNT_THRESHOLD) {
+        result[operator.name] = { ongoing: noStats.active_ongoing, negDelta: negDelta.neg_count };
       }
     }
     return result;

--- a/src/common/alertmanager/alerts/CriticalNegativeDelta.ts
+++ b/src/common/alertmanager/alerts/CriticalNegativeDelta.ts
@@ -2,9 +2,9 @@ import { join } from 'lodash';
 
 import { sentAlerts } from 'common/alertmanager';
 import { ConfigService } from 'common/config';
+import { RegistrySourceOperator } from 'common/validators-registry';
 import { ClickhouseService } from 'storage';
 
-import { RegistrySourceOperator } from '../../validators-registry';
 import { Alert, AlertRequestBody, AlertRuleResult } from './BasicAlert';
 
 const VALIDATORS_WITH_NEGATIVE_DELTA_COUNT_THRESHOLD = 1 / 3;

--- a/src/common/alertmanager/alerts/CriticalSlashing.ts
+++ b/src/common/alertmanager/alerts/CriticalSlashing.ts
@@ -1,9 +1,9 @@
 import { join } from 'lodash';
 
 import { ConfigService } from 'common/config';
+import { RegistrySourceOperator } from 'common/validators-registry';
 import { ClickhouseService } from 'storage';
 
-import { RegistrySourceOperator } from '../../validators-registry';
 import { Alert, AlertRequestBody, AlertRuleResult } from './BasicAlert';
 
 export class CriticalSlashing extends Alert {

--- a/src/common/alertmanager/alerts/CriticalSlashing.ts
+++ b/src/common/alertmanager/alerts/CriticalSlashing.ts
@@ -3,23 +3,25 @@ import { join } from 'lodash';
 import { ConfigService } from 'common/config';
 import { ClickhouseService } from 'storage';
 
+import { RegistrySourceOperator } from '../../validators-registry';
 import { Alert, AlertRequestBody, AlertRuleResult } from './BasicAlert';
 
 export class CriticalSlashing extends Alert {
-  constructor(config: ConfigService, storage: ClickhouseService) {
-    super(CriticalSlashing.name, config, storage);
+  constructor(config: ConfigService, storage: ClickhouseService, operators: RegistrySourceOperator[]) {
+    super(CriticalSlashing.name, config, storage, operators);
   }
 
   async alertRule(epoch: bigint): Promise<AlertRuleResult> {
     const result: AlertRuleResult = {};
     const currOperators = await this.storage.getUserNodeOperatorsStats(epoch);
     const prevOperators = await this.storage.getUserNodeOperatorsStats(epoch - BigInt(this.config.get('FETCH_INTERVAL_SLOTS'))); // compare with previous epoch
-    for (const currOperator of currOperators.filter((o) => o.active_ongoing > this.config.get('CRITICAL_ALERTS_MIN_VAL_COUNT'))) {
-      const prevOperator = prevOperators.find((a) => a.val_nos_name == currOperator.val_nos_name);
+    for (const currOperator of currOperators) {
+      const operator = this.operators.find((o) => +currOperator.val_nos_id == o.index);
+      const prevOperator = prevOperators.find((a) => a.val_nos_id == currOperator.val_nos_id);
       // if count of slashed validators increased, we should alert about it
       const prevSlashed = prevOperator ? prevOperator.slashed : 0;
       if (currOperator.slashed > prevSlashed) {
-        result[currOperator.val_nos_name] = { ongoing: currOperator.active_ongoing, slashed: currOperator.slashed - prevSlashed };
+        result[operator.name] = { ongoing: currOperator.active_ongoing, slashed: currOperator.slashed - prevSlashed };
       }
     }
     return result;

--- a/src/common/alertmanager/critical-alerts.module.ts
+++ b/src/common/alertmanager/critical-alerts.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
 
+import { RegistryModule } from 'common/validators-registry';
 import { ClickhouseModule } from 'storage/clickhouse';
 
-import { RegistryModule } from '../validators-registry';
 import { CriticalAlertsService } from './critical-alerts.service';
 
 @Module({

--- a/src/common/alertmanager/critical-alerts.module.ts
+++ b/src/common/alertmanager/critical-alerts.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
-import { CriticalAlertsService } from './critical-alerts.service';
+
 import { ClickhouseModule } from 'storage/clickhouse';
 
+import { RegistryModule } from '../validators-registry';
+import { CriticalAlertsService } from './critical-alerts.service';
+
 @Module({
-  imports: [ClickhouseModule],
+  imports: [RegistryModule, ClickhouseModule],
   providers: [CriticalAlertsService],
   exports: [CriticalAlertsService],
 })

--- a/src/common/alertmanager/critical-alerts.service.ts
+++ b/src/common/alertmanager/critical-alerts.service.ts
@@ -4,9 +4,9 @@ import got from 'got';
 
 import { ConfigService } from 'common/config';
 import { PrometheusService } from 'common/prometheus';
+import { RegistryService, RegistrySourceOperator } from 'common/validators-registry';
 import { ClickhouseService } from 'storage';
 
-import { RegistryService, RegistrySourceOperator } from '../validators-registry';
 import { AlertRequestBody, PreparedToSendAlert } from './alerts/BasicAlert';
 import { CriticalMissedAttestations } from './alerts/CriticalMissedAttestations';
 import { CriticalMissedProposes } from './alerts/CriticalMissedProposes';

--- a/src/common/prometheus/prometheus.constants.ts
+++ b/src/common/prometheus/prometheus.constants.ts
@@ -13,6 +13,7 @@ export const METRIC_TASK_DURATION_SECONDS = `task_duration_seconds`;
 export const METRIC_TASK_RESULT_COUNT = `task_result_count`;
 export const METRIC_DATA_ACTUALITY = `data_actuality`;
 
+export const METRIC_USER_OPERATORS_IDENTIFIES = `user_operators_identifies`;
 export const METRIC_VALIDATORS = `validators`;
 export const METRIC_USER_VALIDATORS = `user_validators`;
 export const METRIC_FETCH_INTERVAL = `fetch_interval`;

--- a/src/common/prometheus/prometheus.service.ts
+++ b/src/common/prometheus/prometheus.service.ts
@@ -36,6 +36,7 @@ import {
   METRIC_TASK_DURATION_SECONDS,
   METRIC_TASK_RESULT_COUNT,
   METRIC_TOTAL_BALANCE_24H_DIFFERENCE,
+  METRIC_USER_OPERATORS_IDENTIFIES,
   METRIC_USER_SYNC_PARTICIPATION_AVG_PERCENT,
   METRIC_USER_VALIDATORS,
   METRIC_VALIDATORS,
@@ -188,6 +189,12 @@ export class PrometheusService implements OnApplicationBootstrap {
     name: METRIC_TASK_RESULT_COUNT,
     help: 'Count of passed or failed tasks',
     labelNames: ['name', 'status'],
+  });
+
+  public operatorsIdentifies = this.getOrCreateMetric('Gauge', {
+    name: METRIC_USER_OPERATORS_IDENTIFIES,
+    help: 'Operators identifies',
+    labelNames: ['nos_id', 'nos_name'],
   });
 
   public validators = this.getOrCreateMetric('Gauge', {

--- a/src/duty/attestation/attestation.metrics.ts
+++ b/src/duty/attestation/attestation.metrics.ts
@@ -57,79 +57,79 @@ export class AttestationMetrics {
   private async perfectAttestationsLastEpoch() {
     const result = await this.storage.getValidatorCountWithPerfectAttestationsLastEpoch(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       this.prometheus.validatorsCountPerfectAttestation.set({ nos_name: operator.name }, operatorResult ? operatorResult.amount : 0);
     });
-    const other = result.find((a) => a.val_nos_name == 'NULL');
+    const other = result.find((a) => a.val_nos_id == null);
     this.prometheus.otherValidatorsCountPerfectAttestation.set(other ? other.amount : 0);
   }
 
   private async missedAttestationsLastEpoch() {
     const result = await this.storage.getValidatorCountWithMissedAttestationsLastEpoch(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       this.prometheus.validatorsCountMissAttestation.set({ nos_name: operator.name }, operatorResult ? operatorResult.amount : 0);
     });
-    const other = result.find((a) => a.val_nos_name == 'NULL');
+    const other = result.find((a) => a.val_nos_id == null);
     this.prometheus.otherValidatorsCountMissAttestation.set(other ? other.amount : 0);
   }
 
   private async highIncDelayAttestationsLastEpoch() {
     const result = await this.storage.getValidatorCountWithHighIncDelayAttestationsLastEpoch(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       this.prometheus.validatorsCountInvalidAttestation.set(
         { nos_name: operator.name, reason: BadAttReason.HighIncDelay },
         operatorResult ? operatorResult.amount : 0,
       );
     });
-    const other = result.find((a) => a.val_nos_name == 'NULL');
+    const other = result.find((a) => a.val_nos_id == null);
     this.prometheus.otherValidatorsCountInvalidAttestation.set({ reason: BadAttReason.HighIncDelay }, other ? other.amount : 0);
   }
 
   private async invalidHeadAttestationsLastEpoch() {
     const result = await this.storage.getValidatorCountWithInvalidHeadAttestationsLastEpoch(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       this.prometheus.validatorsCountInvalidAttestation.set(
         { nos_name: operator.name, reason: BadAttReason.InvalidHead },
         operatorResult ? operatorResult.amount : 0,
       );
     });
-    const other = result.find((a) => a.val_nos_name == 'NULL');
+    const other = result.find((a) => a.val_nos_id == null);
     this.prometheus.otherValidatorsCountInvalidAttestation.set({ reason: BadAttReason.InvalidHead }, other ? other.amount : 0);
   }
 
   private async invalidTargetAttestationsLastEpoch() {
     const result = await this.storage.getValidatorCountWithInvalidTargetAttestationsLastEpoch(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       this.prometheus.validatorsCountInvalidAttestation.set(
         { nos_name: operator.name, reason: BadAttReason.InvalidTarget },
         operatorResult ? operatorResult.amount : 0,
       );
     });
-    const other = result.find((a) => a.val_nos_name == 'NULL');
+    const other = result.find((a) => a.val_nos_id == null);
     this.prometheus.otherValidatorsCountInvalidAttestation.set({ reason: BadAttReason.InvalidTarget }, other ? other.amount : 0);
   }
 
   private async invalidSourceAttestationsLastEpoch() {
     const result = await this.storage.getValidatorCountWithInvalidSourceAttestationsLastEpoch(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       this.prometheus.validatorsCountInvalidAttestation.set(
         { nos_name: operator.name, reason: BadAttReason.InvalidSource },
         operatorResult ? operatorResult.amount : 0,
       );
     });
-    const other = result.find((a) => a.val_nos_name == 'NULL');
+    const other = result.find((a) => a.val_nos_id == null);
     this.prometheus.otherValidatorsCountInvalidAttestation.set({ reason: BadAttReason.InvalidSource }, other ? other.amount : 0);
   }
 
   private async missAttestationsLastNEpoch() {
     const result = await this.storage.getValidatorCountWithMissedAttestationsLastNEpoch(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       this.prometheus.validatorsCountMissAttestationLastNEpoch.set(
         { nos_name: operator.name, epoch_interval: this.epochInterval },
         operatorResult ? operatorResult.amount : 0,
@@ -140,7 +140,7 @@ export class AttestationMetrics {
   private async highIncDelayAttestationsLastNEpoch() {
     const result = await this.storage.getValidatorCountIncDelayGtOneAttestationsLastNEpoch(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       this.prometheus.validatorsCountInvalidAttestationLastNEpoch.set(
         { nos_name: operator.name, reason: BadAttReason.HighIncDelay, epoch_interval: this.epochInterval },
         operatorResult ? operatorResult.amount : 0,
@@ -151,7 +151,7 @@ export class AttestationMetrics {
   private async invalidHeadAttestationsLastNEpoch() {
     const result = await this.storage.getValidatorCountWithInvalidHeadAttestationsLastNEpoch(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       this.prometheus.validatorsCountInvalidAttestationLastNEpoch.set(
         { nos_name: operator.name, reason: BadAttReason.InvalidHead, epoch_interval: this.epochInterval },
         operatorResult ? operatorResult.amount : 0,
@@ -162,7 +162,7 @@ export class AttestationMetrics {
   private async invalidTargetAttestationsLastNEpoch() {
     const result = await this.storage.getValidatorCountWithInvalidTargetAttestationsLastNEpoch(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       this.prometheus.validatorsCountInvalidAttestationLastNEpoch.set(
         { nos_name: operator.name, reason: BadAttReason.InvalidTarget, epoch_interval: this.epochInterval },
         operatorResult ? operatorResult.amount : 0,
@@ -173,7 +173,7 @@ export class AttestationMetrics {
   private async invalidSourceAttestationsLastNEpoch() {
     const result = await this.storage.getValidatorCountWithInvalidSourceAttestationsLastNEpoch(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       this.prometheus.validatorsCountInvalidAttestationLastNEpoch.set(
         { nos_name: operator.name, reason: BadAttReason.InvalidSource, epoch_interval: this.epochInterval },
         operatorResult ? operatorResult.amount : 0,
@@ -184,7 +184,7 @@ export class AttestationMetrics {
   private async highAvgIncDelayAttestationsOfNEpoch() {
     const result = await this.storage.getValidatorCountHighAvgIncDelayAttestationOfNEpochQuery(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       this.prometheus.validatorsCountHighAvgIncDelayAttestationOfNEpoch.set(
         { nos_name: operator.name, epoch_interval: this.epochInterval },
         operatorResult ? operatorResult.amount : 0,
@@ -195,7 +195,7 @@ export class AttestationMetrics {
   private async incDelayGtTwoAttestationsLastNEpoch() {
     const result = await this.storage.getValidatorCountIncDelayGtTwoAttestationsLastNEpoch(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       this.prometheus.validatorsCountHighIncDelayAttestationLastNEpoch.set(
         { nos_name: operator.name, epoch_interval: this.epochInterval },
         operatorResult ? operatorResult.amount : 0,
@@ -206,7 +206,7 @@ export class AttestationMetrics {
   private async invalidAttestationPropertyGtOneLastNEpoch() {
     const result = await this.storage.getValidatorCountWithInvalidAttestationsPropertyGtOneLastNEpoch(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id != null && +a.val_nos_id == operator.index);
       this.prometheus.validatorsCountInvalidAttestationPropertyLastNEpoch.set(
         { nos_name: operator.name, epoch_interval: this.epochInterval },
         operatorResult ? operatorResult.amount : 0,
@@ -222,7 +222,7 @@ export class AttestationMetrics {
         possibleHighRewardValidators,
       );
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((a) => a.val_nos_name == operator.name);
+      const operatorResult = result.find((a) => a.val_nos_id == operator.index);
       this.prometheus.highRewardValidatorsCountMissAttestationLastNEpoch.set(
         { nos_name: operator.name, epoch_interval: this.epochInterval },
         operatorResult ? operatorResult.amount : 0,

--- a/src/duty/propose/propose.metrics.ts
+++ b/src/duty/propose/propose.metrics.ts
@@ -29,20 +29,20 @@ export class ProposeMetrics {
   private async goodProposes() {
     const result = await this.storage.getValidatorsCountWithGoodProposes(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((p) => p.val_nos_name == operator.name);
+      const operatorResult = result.find((p) => p.val_nos_id != null && +p.val_nos_id == operator.index);
       this.prometheus.validatorsCountGoodPropose.set({ nos_name: operator.name }, operatorResult ? operatorResult.amount : 0);
     });
-    const other = result.find((p) => p.val_nos_name == 'NULL');
+    const other = result.find((p) => p.val_nos_id == null);
     this.prometheus.otherValidatorsCountGoodPropose.set(other ? other.amount : 0);
   }
 
   private async missProposes() {
     const result = await this.storage.getValidatorsCountWithMissedProposes(this.processedEpoch);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((p) => p.val_nos_name == operator.name);
+      const operatorResult = result.find((p) => p.val_nos_id != null && +p.val_nos_id == operator.index);
       this.prometheus.validatorsCountMissPropose.set({ nos_name: operator.name }, operatorResult ? operatorResult.amount : 0);
     });
-    const other = result.find((p) => p.val_nos_name == 'NULL');
+    const other = result.find((p) => p.val_nos_id == null);
     this.prometheus.otherValidatorsCountMissPropose.set(other ? other.amount : 0);
   }
 
@@ -51,7 +51,7 @@ export class ProposeMetrics {
     if (possibleHighRewardValidators.length > 0)
       result = await this.storage.getValidatorsCountWithMissedProposes(this.processedEpoch, possibleHighRewardValidators);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((p) => p.val_nos_name == operator.name);
+      const operatorResult = result.find((p) => p.val_nos_id != null && +p.val_nos_id == operator.index);
       this.prometheus.highRewardValidatorsCountMissPropose.set({ nos_name: operator.name }, operatorResult ? operatorResult.amount : 0);
     });
   }

--- a/src/duty/sync/sync.metrics.ts
+++ b/src/duty/sync/sync.metrics.ts
@@ -47,8 +47,9 @@ export class SyncMetrics {
 
   private async operatorAvgSyncPercents() {
     const result = await this.storage.getOperatorSyncParticipationAvgPercents(this.processedEpoch);
-    result.forEach((p) => {
-      this.prometheus.operatorSyncParticipationAvgPercent.set({ nos_name: p.val_nos_name }, p.avg_percent);
+    this.operators.forEach((operator) => {
+      const operatorResult = result.find((p) => p.val_nos_id != null && +p.val_nos_id == operator.index);
+      this.prometheus.operatorSyncParticipationAvgPercent.set({ nos_name: operator.name }, operatorResult ? operatorResult.avg_percent : 0);
     });
   }
 
@@ -71,23 +72,23 @@ export class SyncMetrics {
   private async goodSyncParticipationLastEpoch(chainAvgSyncPercent: number) {
     const result = await this.storage.getValidatorsCountWithGoodSyncParticipationLastNEpoch(this.processedEpoch, 1, chainAvgSyncPercent);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((p) => p.val_nos_name == operator.name);
+      const operatorResult = result.find((p) => p.val_nos_id != null && +p.val_nos_id == operator.index);
       this.prometheus.validatorsCountWithGoodSyncParticipation.set({ nos_name: operator.name }, operatorResult ? operatorResult.amount : 0);
     });
-    const other = result.find((p) => p.val_nos_name == 'NULL');
+    const other = result.find((p) => p.val_nos_id == null);
     this.prometheus.otherValidatorsCountWithGoodSyncParticipation.set(other ? other.amount : 0);
   }
 
   private async badSyncParticipationLastEpoch(chainAvgSyncPercent: number) {
     const result = await this.storage.getValidatorsCountWithBadSyncParticipationLastNEpoch(this.processedEpoch, 1, chainAvgSyncPercent);
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((p) => p.val_nos_name == operator.name);
+      const operatorResult = result.find((p) => p.val_nos_id != null && +p.val_nos_id == operator.index);
       this.prometheus.validatorsCountWithSyncParticipationLessAvg.set(
         { nos_name: operator.name },
         operatorResult ? operatorResult.amount : 0,
       );
     });
-    const other = result.find((p) => p.val_nos_name == 'NULL');
+    const other = result.find((p) => p.val_nos_id == null);
     this.prometheus.otherValidatorsCountWithSyncParticipationLessAvg.set(other ? other.amount : 0);
   }
 
@@ -98,7 +99,7 @@ export class SyncMetrics {
       chainAvgSyncPercent,
     );
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((p) => p.val_nos_name == operator.name);
+      const operatorResult = result.find((p) => p.val_nos_id != null && +p.val_nos_id == operator.index);
       this.prometheus.validatorsCountWithSyncParticipationLessAvgLastNEpoch.set(
         { nos_name: operator.name, epoch_interval: this.epochInterval },
         operatorResult ? operatorResult.amount : 0,
@@ -116,7 +117,7 @@ export class SyncMetrics {
         possibleHighRewardValidators,
       );
     this.operators.forEach((operator) => {
-      const operatorResult = result.find((p) => p.val_nos_name == operator.name);
+      const operatorResult = result.find((p) => p.val_nos_id != null && +p.val_nos_id == operator.index);
       this.prometheus.highRewardValidatorsCountWithSyncParticipationLessAvgLastNEpoch.set(
         { nos_name: operator.name, epoch_interval: this.epochInterval },
         operatorResult ? operatorResult.amount : 0,

--- a/src/storage/clickhouse/clickhouse.service.ts
+++ b/src/storage/clickhouse/clickhouse.service.ts
@@ -406,8 +406,8 @@ export class ClickhouseService implements OnModuleInit {
     return Number(total_diff);
   }
 
-  public async getOperatorBalance24hDifference(epoch: bigint): Promise<{ val_nos_name; diff }[]> {
-    return (await this.select<{ val_nos_name; diff }[]>(operatorBalance24hDifferenceQuery(epoch))).map((v) => ({
+  public async getOperatorBalance24hDifference(epoch: bigint): Promise<{ val_nos_id; diff }[]> {
+    return (await this.select<{ val_nos_id; diff }[]>(operatorBalance24hDifferenceQuery(epoch))).map((v) => ({
       ...v,
       diff: Number(v.diff),
     }));

--- a/src/storage/clickhouse/clickhouse.types.ts
+++ b/src/storage/clickhouse/clickhouse.types.ts
@@ -5,41 +5,41 @@ export interface ValidatorsStatusStats {
 }
 
 export interface NOsDelta {
-  val_nos_name: string;
+  val_nos_id: string;
   delta: number;
 }
 
 export interface NOsValidatorsNegDeltaCount {
-  val_nos_name: string;
+  val_nos_id: string;
   neg_count: number;
 }
 
 export interface NOsValidatorsSyncAvgPercent {
-  val_nos_name: string;
+  val_nos_id: string;
   avg_percent: number;
 }
 
 export interface NOsValidatorsSyncByConditionCount {
-  val_nos_name: string;
+  val_nos_id: string;
   amount: number;
 }
 
 export interface NOsValidatorsByConditionAttestationCount {
-  val_nos_name: string;
+  val_nos_id: string;
   amount: number;
 }
 
 export interface NOsValidatorsByConditionProposeCount {
-  val_nos_name: string;
+  val_nos_id: string;
   amount: number;
 }
 
 export interface NOsValidatorsStatusStats extends ValidatorsStatusStats {
-  val_nos_name: string;
+  val_nos_id: string;
 }
 
 export interface NOsProposesStats {
-  val_nos_name: string;
+  val_nos_id: string;
   all: number;
   missed: number;
 }


### PR DESCRIPTION
We should aggregate values by `id` instead of `name` and add new metric `user_operators_identifies` that should help to match operator's name with his `id` for something (eg. alerting)