### PR TITLE
fix: revert old approach and insert data in chunks

### DIFF
--- a/src/common/config/env.validation.ts
+++ b/src/common/config/env.validation.ts
@@ -114,6 +114,11 @@ export class EnvironmentVariables {
   @Transform(({ value }) => parseInt(value, 10), { toClassOnly: true })
   public DB_MAX_BACKOFF_SEC = 120;
 
+  @IsNumber()
+  @Min(100)
+  @Transform(({ value }) => parseInt(value, 10), { toClassOnly: true })
+  public DB_INSERT_CHUNK_SIZE = 100_000;
+
   @IsNotEmpty()
   @IsInt()
   @Min(1)

--- a/src/duty/duty.service.ts
+++ b/src/duty/duty.service.ts
@@ -1,5 +1,3 @@
-import { Readable } from 'stream';
-
 import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 
@@ -140,8 +138,7 @@ export class DutyService {
 
   protected async writeSummary(): Promise<any> {
     this.logger.log('Writing summary of duties into DB');
-    const stream = new Readable({ objectMode: true });
-    await Promise.all([this.storage.writeSummary(stream), this.streamSummary(stream)]);
+    await this.storage.writeSummary(this.summary.values());
     this.summary.clear();
   }
 
@@ -150,15 +147,5 @@ export class DutyService {
     const meta = this.summary.getMeta();
     await this.storage.writeEpochMeta(epoch, meta);
     this.summary.clearMeta();
-  }
-
-  protected async streamSummary(stream: Readable) {
-    const summary = this.summary.values();
-    let next = summary.next();
-    while (!next.done) {
-      stream.push({ ...next.value, att_meta: undefined, sync_meta: undefined });
-      next = summary.next();
-    }
-    stream.push(null);
   }
 }


### PR DESCRIPTION
Broken pipe error are happened very frequently on infra instance. Error is not reproduced locally, but I assume it is due to a buffer overflow. The old approach should bring a soft and safe data insertion