### PR TITLE
feat: safe epoch processing

### DIFF
--- a/docker/grafana/provisioning/dashboards/operators.json
+++ b/docker/grafana/provisioning/dashboards/operators.json
@@ -24,8 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 14,
-  "iteration": 1671106440275,
+  "iteration": 1672296019449,
   "links": [
     {
       "asDropdown": false,
@@ -945,8 +944,8 @@
           "format": "table",
           "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
           "intervalFactor": 1,
-          "query": "SELECT\n  current.val_balance - previous.val_balance AS GWei,\n  current.val_id as Validator\nFROM \n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_name = '${nos_name_var}' AND\n      epoch = ${epoch_number_var}\n  ) AS current\nLEFT JOIN\n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_name = '${nos_name_var}' AND\n      epoch = ${epoch_number_var} - 6\n  ) AS previous\nON\n  previous.val_nos_id = current.val_nos_id AND \n  previous.val_id = current.val_id\nHAVING (current.val_balance - previous.val_balance) < 0\nORDER BY GWei ASC\nLIMIT ${limit}",
-          "rawQuery": "SELECT\n  current.val_balance - previous.val_balance AS GWei,\n  current.val_id as Validator\nFROM \n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_name = 'EU Nordic & East' AND\n      epoch = 161310\n  ) AS current\nLEFT JOIN\n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_name = 'EU Nordic & East' AND\n      epoch = 161310 - 6\n  ) AS previous\nON\n  previous.val_nos_id = current.val_nos_id AND \n  previous.val_id = current.val_id\nHAVING (current.val_balance - previous.val_balance) < 0\nORDER BY GWei ASC\nLIMIT 100",
+          "query": "SELECT\n  current.val_balance - previous.val_balance AS GWei,\n  current.val_id as Validator\nFROM \n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_name = '${nos_name_var}' AND\n      epoch = ${epoch_number_var}\n    LIMIT 1 by val_id\n  ) AS current\nLEFT JOIN\n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_name = '${nos_name_var}' AND\n      epoch = ${epoch_number_var} - 6\n    LIMIT 1 by val_id\n  ) AS previous\nON\n  previous.val_nos_id = current.val_nos_id AND \n  previous.val_id = current.val_id\nHAVING (current.val_balance - previous.val_balance) < 0\nORDER BY GWei ASC\nLIMIT ${limit}",
+          "rawQuery": "SELECT\n  current.val_balance - previous.val_balance AS GWei,\n  current.val_id as Validator\nFROM \n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_name = 'Allnodes' AND\n      epoch = 170498\n    LIMIT 1 by val_id\n  ) AS current\nLEFT JOIN\n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_name = 'Allnodes' AND\n      epoch = 170498 - 6\n    LIMIT 1 by val_id\n  ) AS previous\nON\n  previous.val_nos_id = current.val_nos_id AND \n  previous.val_id = current.val_id\nHAVING (current.val_balance - previous.val_balance) < 0\nORDER BY GWei ASC\nLIMIT 100",
           "refId": "A",
           "round": "0s",
           "skip_comments": true
@@ -1066,8 +1065,8 @@
           "format": "table",
           "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
           "intervalFactor": 1,
-          "query": "SELECT\n  block_to_propose as Block,\n  val_id as Validator\nFROM validators_summary\nWHERE is_proposer = 1 AND block_proposed = 0 AND (epoch = ${epoch_number_var}) AND val_nos_name = '${nos_name_var}'\nORDER BY block_to_propose DESC, val_id",
-          "rawQuery": "SELECT\n  block_to_propose as Block,\n  val_id as Validator\nFROM validators_summary\nWHERE is_proposer = 1 AND block_proposed = 0 AND (epoch = 161310) AND val_nos_name = 'EU Nordic & East'\nORDER BY block_to_propose DESC, val_id",
+          "query": "SELECT\n  block_to_propose as Block,\n  val_id as Validator\nFROM validators_summary\nWHERE is_proposer = 1 AND block_proposed = 0 AND (epoch = ${epoch_number_var}) AND val_nos_name = '${nos_name_var}'\nORDER BY block_to_propose DESC, val_id\nLIMIT 1 by val_id",
+          "rawQuery": "SELECT\n  block_to_propose as Block,\n  val_id as Validator\nFROM validators_summary\nWHERE is_proposer = 1 AND block_proposed = 0 AND (epoch = 170499) AND val_nos_name = 'Allnodes'\nORDER BY block_to_propose DESC, val_id\nLIMIT 1 by val_id",
           "refId": "A",
           "round": "0s",
           "skip_comments": true
@@ -1200,8 +1199,8 @@
           "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
           "hide": false,
           "intervalFactor": 1,
-          "query": "SELECT\n  val_id as Validator\nFROM (\n  SELECT\n    val_id,\n    count() AS count_fail\n  FROM\n    validators_summary\n  WHERE\n    is_sync = 1 AND sync_percent < (${chain_sync_avg_participation} - ${sync_participation_distance_var}) AND\n    (epoch <= ${epoch_number_var} AND epoch > (${epoch_number_var} - ${sync_epochs_var})) AND\n    val_nos_name = '${nos_name_var}'\n  GROUP BY val_id\n)\nWHERE count_fail = ${sync_epochs_var}\nORDER BY count_fail DESC, val_id",
-          "rawQuery": "SELECT\n  val_id as Validator\nFROM (\n  SELECT\n    val_id,\n    count() AS count_fail\n  FROM\n    validators_summary\n  WHERE\n    is_sync = 1 AND sync_percent < (97.296142578125 - 10) AND\n    (epoch <= 161310 AND epoch > (161310 - 3)) AND\n    val_nos_name = 'EU Nordic & East'\n  GROUP BY val_id\n)\nWHERE count_fail = 3\nORDER BY count_fail DESC, val_id",
+          "query": "SELECT\n  val_id as Validator\nFROM (\n  SELECT\n    val_id,\n    count() AS count_fail\n  FROM (\n    SELECT val_id\n    FROM validators_summary\n    WHERE\n      is_sync = 1 AND sync_percent < (${chain_sync_avg_participation} - ${sync_participation_distance_var}) AND\n      (epoch <= ${epoch_number_var} AND epoch > (${epoch_number_var} - ${sync_epochs_var})) AND\n      val_nos_name = '${nos_name_var}'\n    LIMIT 1 by epoch, val_id  \n  )\n  GROUP BY val_id\n)\nWHERE count_fail = ${sync_epochs_var}\nORDER BY count_fail DESC, val_id",
+          "rawQuery": "SELECT\n  val_id as Validator\nFROM (\n  SELECT\n    val_id,\n    count() AS count_fail\n  FROM (\n    SELECT val_id\n    FROM validators_summary\n    WHERE\n      is_sync = 1 AND sync_percent < (98.48790320474654 - 0) AND\n      (epoch <= 170500 AND epoch > (170500 - 3)) AND\n      val_nos_name = 'Allnodes'\n    LIMIT 1 by epoch, val_id  \n  )\n  GROUP BY val_id\n)\nWHERE count_fail = 3\nORDER BY count_fail DESC, val_id",
           "refId": "B",
           "round": "0s",
           "skip_comments": true
@@ -1300,8 +1299,8 @@
           "format": "table",
           "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
           "intervalFactor": 1,
-          "query": "\nSELECT\n  val_id as Validator\nFROM (\n    SELECT\n      val_id,\n      count() as count_fail\n    FROM validators_summary\n    WHERE att_happened = 0 AND \n    (epoch <= ${epoch_number_var} AND epoch > (${epoch_number_var} - ${att_epochs_var})) AND\n    val_nos_name = '${nos_name_var}'\n    GROUP BY val_id\n)\nWHERE count_fail = ${att_epochs_var}\nORDER BY count_fail DESC, val_id\nLIMIT ${limit}",
-          "rawQuery": "SELECT\n  val_id as Validator\nFROM (\n    SELECT\n      val_id,\n      count() as count_fail\n    FROM validators_summary\n    WHERE att_happened = 0 AND \n    (epoch <= 161309 AND epoch > (161309 - 3)) AND\n    val_nos_name = 'EU Nordic & East'\n    GROUP BY val_id\n)\nWHERE count_fail = 3\nORDER BY count_fail DESC, val_id\nLIMIT 100",
+          "query": "\nSELECT\n  val_id as Validator\nFROM (\n    SELECT\n      val_id,\n      count() as count_fail\n    FROM (\n      SELECT val_id\n      FROM validators_summary\n      WHERE \n        att_happened = 0 AND val_nos_name = '${nos_name_var}' AND\n        (epoch <= ${epoch_number_var} AND epoch > (${epoch_number_var} - ${att_epochs_var}))\n      LIMIT 1 by epoch, val_id\n    )\n    GROUP BY val_id\n)\nWHERE count_fail = ${att_epochs_var}\nORDER BY count_fail DESC, val_id\nLIMIT ${limit}",
+          "rawQuery": "SELECT\n  val_id as Validator\nFROM (\n    SELECT\n      val_id,\n      count() as count_fail\n    FROM (\n      SELECT val_id\n      FROM validators_summary\n      WHERE \n        att_happened = 0 AND val_nos_name = 'Allnodes' AND\n        (epoch <= 170499 AND epoch > (170499 - 3))\n      LIMIT 1 by epoch, val_id\n    )\n    GROUP BY val_id\n)\nWHERE count_fail = 3\nORDER BY count_fail DESC, val_id\nLIMIT 100",
           "refId": "A",
           "round": "0s",
           "skip_comments": true
@@ -1412,8 +1411,8 @@
           "format": "table",
           "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
           "intervalFactor": 1,
-          "query": "SELECT\n  val_id as Validator,\n  count() as count_fail\nFROM validators_summary\nWHERE\n  val_nos_name = '${nos_name_var}' AND\n  att_happened = 1 AND\n  att_inc_delay > 1 AND\n  (epoch <= ${epoch_number_var} AND epoch > (${epoch_number_var} - ${att_epochs_var}))\nGROUP BY val_id, val_nos_name\nHAVING count_fail = ${att_epochs_var}\nORDER BY count_fail DESC, val_id\nLIMIT ${limit}",
-          "rawQuery": "SELECT\n  val_id as Validator,\n  count() as count_fail\nFROM validators_summary\nWHERE\n  val_nos_name = 'EU Nordic & East' AND\n  att_happened = 1 AND\n  att_inc_delay > 1 AND\n  (epoch <= 161310 AND epoch > (161310 - 3))\nGROUP BY val_id, val_nos_name\nHAVING count_fail = 3\nORDER BY count_fail DESC, val_id\nLIMIT 100",
+          "query": "SELECT\n  val_id as Validator,\n  count() as count_fail\nFROM (\n  SELECT val_id\n  FROM validators_summary\n  WHERE\n    val_nos_name = '${nos_name_var}' AND\n    att_happened = 1 AND\n    att_inc_delay > 1 AND\n    (epoch <= ${epoch_number_var} AND epoch > (${epoch_number_var} - ${att_epochs_var}))\n  LIMIT 1 by epoch, val_id\n)\nGROUP BY val_id\nHAVING count_fail = ${att_epochs_var}\nORDER BY count_fail DESC, val_id\nLIMIT ${limit}",
+          "rawQuery": "SELECT\n  val_id as Validator,\n  count() as count_fail\nFROM (\n  SELECT val_id\n  FROM validators_summary\n  WHERE\n    val_nos_name = 'Allnodes' AND\n    att_happened = 1 AND\n    att_inc_delay > 1 AND\n    (epoch <= 170500 AND epoch > (170500 - 3))\n  LIMIT 1 by epoch, val_id\n)\nGROUP BY val_id\nHAVING count_fail = 3\nORDER BY count_fail DESC, val_id\nLIMIT 100",
           "refId": "A",
           "round": "0s",
           "skip_comments": true
@@ -1525,8 +1524,8 @@
           "format": "table",
           "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
           "intervalFactor": 1,
-          "query": "SELECT\n  val_id as Validator,\n  count() as count_fail\nFROM validators_summary\nWHERE\n  val_nos_name = '${nos_name_var}' AND\n  (att_valid_head + att_valid_target + att_valid_source = 1) AND\n  (epoch <= ${epoch_number_var} AND epoch > (${epoch_number_var} - ${att_epochs_var}))\nGROUP BY val_id, val_nos_name\nHAVING count_fail = ${att_epochs_var}\nORDER BY count_fail DESC, val_id\nLIMIT ${limit}",
-          "rawQuery": "SELECT\n  val_id as Validator,\n  count() as count_fail\nFROM validators_summary\nWHERE\n  val_nos_name = 'EU Nordic & East' AND\n  (att_valid_head + att_valid_target + att_valid_source = 1) AND\n  (epoch <= 161310 AND epoch > (161310 - 3))\nGROUP BY val_id, val_nos_name\nHAVING count_fail = 3\nORDER BY count_fail DESC, val_id\nLIMIT 100",
+          "query": "SELECT\n  val_id as Validator,\n  count() as count_fail\nFROM (\n  SELECT val_id\n  FROM validators_summary\n  WHERE\n    val_nos_name = '${nos_name_var}' AND\n    (att_valid_head + att_valid_target + att_valid_source = 1) AND\n    (epoch <= ${epoch_number_var} AND epoch > (${epoch_number_var} - ${att_epochs_var}))\n  LIMIT 1 by epoch, val_id\n)\nGROUP BY val_id\nHAVING count_fail = ${att_epochs_var}\nORDER BY count_fail DESC, val_id\nLIMIT ${limit}",
+          "rawQuery": "SELECT\n  val_id as Validator,\n  count() as count_fail\nFROM (\n  SELECT val_id\n  FROM validators_summary\n  WHERE\n    val_nos_name = 'Allnodes' AND\n    (att_valid_head + att_valid_target + att_valid_source = 1) AND\n    (epoch <= 170500 AND epoch > (170500 - 3))\n  LIMIT 1 by epoch, val_id\n)\nGROUP BY val_id\nHAVING count_fail = 3\nORDER BY count_fail DESC, val_id\nLIMIT 100",
           "refId": "A",
           "round": "0s",
           "skip_comments": true
@@ -1558,7 +1557,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": null
               }
             ]
           }
@@ -1612,7 +1612,7 @@
           }
         ]
       },
-      "pluginVersion": "8.5.13",
+      "pluginVersion": "8.5.15",
       "targets": [
         {
           "datasource": {
@@ -1624,8 +1624,8 @@
           "format": "table",
           "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
           "intervalFactor": 1,
-          "query": "SELECT\n    val_status as Status,\n    val_id as Validator\nFROM validators_summary\nWHERE (val_status == 'active_slashed' OR val_status == 'exited_slashed' OR val_slashed == 1) and val_nos_name = '${nos_name_var}' and epoch = ${epoch_number_var}\nLIMIT ${limit}",
-          "rawQuery": "SELECT\n    val_status as Status,\n    val_id as Validator\nFROM validators_summary\nWHERE (val_status == 'active_slashed' OR val_status == 'exited_slashed' OR val_slashed == 1) and val_nos_name = 'EU Nordic & East' and epoch = 161310\nLIMIT 100",
+          "query": "SELECT\n    val_status as Status,\n    val_id as Validator\nFROM validators_summary\nWHERE (val_status == 'active_slashed' OR val_status == 'exited_slashed' OR val_slashed == 1) and val_nos_name = '${nos_name_var}' and epoch = ${epoch_number_var}\nLIMIT 1 by val_id",
+          "rawQuery": "SELECT\n    val_status as Status,\n    val_id as Validator\nFROM validators_summary\nWHERE (val_status == 'active_slashed' OR val_status == 'exited_slashed' OR val_slashed == 1) and val_nos_name = 'Allnodes' and epoch = 170499\nLIMIT 1 by val_id",
           "refId": "A",
           "round": "0s",
           "skip_comments": true
@@ -1696,7 +1696,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               },
@@ -1802,7 +1803,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "transparent",
@@ -1896,7 +1898,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "transparent",
@@ -1964,7 +1967,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -2038,10 +2042,10 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
-              "datasource": {
+                  "datasource": {
                 "type": "vertamedia-clickhouse-datasource",
                 "uid": "PDEE91DDB90597936"
               },
@@ -2050,8 +2054,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "SELECT\n  current.val_balance - previous.val_balance AS GWei,\n  current.val_id as Validator\nFROM \n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = ${epoch_number_var}\n  ) AS current\nLEFT JOIN\n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = ${epoch_number_var} - 6\n  ) AS previous\nON\n  previous.val_nos_id = current.val_nos_id AND \n  previous.val_id = current.val_id\nORDER BY GWei ASC\nLIMIT 100",
-              "rawQuery": "SELECT\n  current.val_balance - previous.val_balance AS GWei,\n  current.val_id as Validator\nFROM \n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = 161308\n  ) AS current\nLEFT JOIN\n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = 161308 - 6\n  ) AS previous\nON\n  previous.val_nos_id = current.val_nos_id AND \n  previous.val_id = current.val_id\nORDER BY GWei ASC\nLIMIT 100",
+              "query": "SELECT\n  current.val_balance - previous.val_balance AS GWei,\n  current.val_id as Validator\nFROM \n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = ${epoch_number_var}\n    LIMIT 1 by val_id\n  ) AS current\nLEFT JOIN\n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = ${epoch_number_var} - 6\n    LIMIT 1 by val_id\n  ) AS previous\nON\n  previous.val_nos_id = current.val_nos_id AND \n  previous.val_id = current.val_id\nORDER BY GWei ASC\nLIMIT 100",
+              "rawQuery": "SELECT\n  current.val_balance - previous.val_balance AS GWei,\n  current.val_id as Validator\nFROM \n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = 170500\n    LIMIT 1 by val_id\n  ) AS current\nLEFT JOIN\n  (\n    SELECT val_balance, val_id, val_nos_id \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = 170500 - 6\n    LIMIT 1 by val_id\n  ) AS previous\nON\n  previous.val_nos_id = current.val_nos_id AND \n  previous.val_id = current.val_id\nORDER BY GWei ASC\nLIMIT 100",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -2108,7 +2112,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "dark-red"
+                    "color": "dark-red",
+                    "value": null
                   }
                 ]
               },
@@ -2193,7 +2198,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -2269,10 +2275,10 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
-              "datasource": {
+                  "datasource": {
                 "type": "vertamedia-clickhouse-datasource",
                 "uid": "PDEE91DDB90597936"
               },
@@ -2281,8 +2287,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "SELECT\n  block_to_propose as Block,\n  val_id as Validator\nFROM validators_summary\nWHERE is_proposer = 1 AND val_nos_name = '${nos_name_var}' AND block_proposed = 0 AND (epoch <= ${epoch_number_var} AND epoch > (${epoch_number_var} - ${epochs_range}))\nORDER BY block_to_propose DESC, val_id",
-              "rawQuery": "SELECT\n  block_to_propose as Block,\n  val_id as Validator\nFROM validators_summary\nWHERE is_proposer = 1 AND val_nos_name = 'EU Nordic & East' AND block_proposed = 0 AND (epoch <= 161308 AND epoch > (161308 - 48))\nORDER BY block_to_propose DESC, val_id",
+              "query": "SELECT\n  block_to_propose as Block,\n  val_id as Validator\nFROM validators_summary\nWHERE is_proposer = 1 AND val_nos_name = '${nos_name_var}' AND block_proposed = 0 AND (epoch <= ${epoch_number_var} AND epoch > (${epoch_number_var} - ${epochs_range}))\nORDER BY block_to_propose DESC, val_id\nLIMIT 1 by epoch, val_id",
+              "rawQuery": "SELECT\n  block_to_propose as Block,\n  val_id as Validator\nFROM validators_summary\nWHERE is_proposer = 1 AND val_nos_name = 'Allnodes' AND block_proposed = 0 AND (epoch <= 170500 AND epoch > (170500 - 9))\nORDER BY block_to_propose DESC, val_id\nLIMIT 1 by epoch, val_id",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -2336,7 +2342,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -2448,7 +2455,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2646,7 +2654,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -2720,10 +2729,10 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
-              "datasource": {
+                  "datasource": {
                 "type": "vertamedia-clickhouse-datasource",
                 "uid": "PDEE91DDB90597936"
               },
@@ -2732,8 +2741,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "SELECT\n    sync_percent as Percent,\n    val_id as Validator\nFROM\n    validators_summary\nWHERE is_sync = 1 AND val_nos_name = '${nos_name_var}' AND epoch = ${epoch_number_var} AND sync_percent < (${chain_sync_avg_participation} - ${sync_participation_distance_var})\nORDER BY sync_percent",
-              "rawQuery": "SELECT\n    sync_percent as Percent,\n    val_id as Validator\nFROM\n    validators_summary\nWHERE is_sync = 1 AND val_nos_name = 'EU Nordic & East' AND epoch = 161308 AND sync_percent < (97.222900390625 - 10)\nORDER BY sync_percent",
+              "query": "SELECT\n    sync_percent as Percent,\n    val_id as Validator\nFROM\n    validators_summary\nWHERE is_sync = 1 AND val_nos_name = '${nos_name_var}' AND epoch = ${epoch_number_var} AND sync_percent < (${chain_sync_avg_participation} - ${sync_participation_distance_var})\nORDER BY sync_percent\nLIMIT 1 by val_id",
+              "rawQuery": "SELECT\n    sync_percent as Percent,\n    val_id as Validator\nFROM\n    validators_summary\nWHERE is_sync = 1 AND val_nos_name = 'Allnodes' AND epoch = 170501 AND sync_percent < (95.4833984375 - 0)\nORDER BY sync_percent\nLIMIT 1 by val_id",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -2786,7 +2795,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -2923,7 +2933,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -2997,10 +3008,10 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
-              "datasource": {
+                  "datasource": {
                 "type": "vertamedia-clickhouse-datasource",
                 "uid": "PDEE91DDB90597936"
               },
@@ -3009,8 +3020,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "    SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_happened = 0 AND val_nos_name = '${nos_name_var}' AND epoch = ${epoch_number_var}\n    ORDER BY val_id\n    LIMIT ${limit}",
-              "rawQuery": "SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_happened = 0 AND val_nos_name = 'Figment' AND epoch = 164441\n    ORDER BY val_id\n    LIMIT 100",
+              "query": "    SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_happened = 0 AND val_nos_name = '${nos_name_var}' AND epoch = ${epoch_number_var}\n    ORDER BY val_id\n    LIMIT 1 by val_id\n    LIMIT ${limit}",
+              "rawQuery": "SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_happened = 0 AND val_nos_name = 'Allnodes' AND epoch = 170501\n    ORDER BY val_id\n    LIMIT 1 by val_id\n    LIMIT 100",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -3064,7 +3075,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -3167,7 +3179,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -3241,10 +3254,10 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
-              "datasource": {
+                  "datasource": {
                 "type": "vertamedia-clickhouse-datasource",
                 "uid": "PDEE91DDB90597936"
               },
@@ -3253,8 +3266,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "\n    SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_happened = 1 AND att_inc_delay > 1 AND val_nos_name = '${nos_name_var}' AND epoch = ${epoch_number_var}\n    ORDER BY val_id\n    LIMIT ${limit}",
-              "rawQuery": "SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_happened = 1 AND att_inc_delay > 1 AND val_nos_name = 'Figment' AND epoch = 164441\n    ORDER BY val_id\n    LIMIT 100",
+              "query": "\n    SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_happened = 1 AND att_inc_delay > 1 AND val_nos_name = '${nos_name_var}' AND epoch = ${epoch_number_var}\n    ORDER BY val_id\n    LIMIT 1 by val_id\n    LIMIT ${limit}",
+              "rawQuery": "SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_happened = 1 AND att_inc_delay > 1 AND val_nos_name = 'Allnodes' AND epoch = 170501\n    ORDER BY val_id\n    LIMIT 1 by val_id\n    LIMIT 100",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -3308,7 +3321,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -3411,7 +3425,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -3497,10 +3512,10 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
-              "datasource": {
+                  "datasource": {
                 "type": "vertamedia-clickhouse-datasource",
                 "uid": "PDEE91DDB90597936"
               },
@@ -3509,8 +3524,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "\n    SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_valid_head = 0 AND val_nos_name = '${nos_name_var}' AND epoch = ${epoch_number_var}\n    ORDER BY val_id\n    LIMIT ${limit}",
-              "rawQuery": "SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_valid_head = 0 AND val_nos_name = 'Figment' AND epoch = 164441\n    ORDER BY val_id\n    LIMIT 100",
+              "query": "\n    SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_valid_head = 0 AND val_nos_name = '${nos_name_var}' AND epoch = ${epoch_number_var}\n    ORDER BY val_id\n    LIMIT 1 BY val_id\n    LIMIT ${limit}",
+              "rawQuery": "SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_valid_head = 0 AND val_nos_name = 'Allnodes' AND epoch = 170501\n    ORDER BY val_id\n    LIMIT 1 BY val_id\n    LIMIT 100",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -3564,7 +3579,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -3667,7 +3683,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -3741,10 +3758,10 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
-              "datasource": {
+                  "datasource": {
                 "type": "vertamedia-clickhouse-datasource",
                 "uid": "PDEE91DDB90597936"
               },
@@ -3753,8 +3770,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "\n    SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_valid_target = 0 AND val_nos_name = '${nos_name_var}' AND epoch = ${epoch_number_var}\n    ORDER BY val_id\n    LIMIT ${limit}",
-              "rawQuery": "SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_valid_target = 0 AND val_nos_name = 'Figment' AND epoch = 164400\n    ORDER BY val_id\n    LIMIT 100",
+              "query": "\n    SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_valid_target = 0 AND val_nos_name = '${nos_name_var}' AND epoch = ${epoch_number_var}\n    ORDER BY val_id\n    LIMIT 1 by val_id\n    LIMIT ${limit}",
+              "rawQuery": "SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_valid_target = 0 AND val_nos_name = 'Allnodes' AND epoch = 170501\n    ORDER BY val_id\n    LIMIT 1 by val_id\n    LIMIT 100",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -3808,7 +3825,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -3911,7 +3929,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -3985,10 +4004,10 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
-              "datasource": {
+                  "datasource": {
                 "type": "vertamedia-clickhouse-datasource",
                 "uid": "PDEE91DDB90597936"
               },
@@ -3997,8 +4016,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "\n    SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_valid_source = 0 AND val_nos_name = '${nos_name_var}' AND epoch = ${epoch_number_var}\n    ORDER BY val_id\n    LIMIT ${limit}",
-              "rawQuery": "SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_valid_source = 0 AND val_nos_name = 'Figment' AND epoch = 164400\n    ORDER BY val_id\n    LIMIT 100",
+              "query": "\n    SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_valid_source = 0 AND val_nos_name = '${nos_name_var}' AND epoch = ${epoch_number_var}\n    ORDER BY val_id\n    LIMIT 1 by val_id\n    LIMIT ${limit}",
+              "rawQuery": "SELECT\n      val_id as Validator\n    FROM validators_summary\n    WHERE att_valid_source = 0 AND val_nos_name = 'Allnodes' AND epoch = 170501\n    ORDER BY val_id\n    LIMIT 1 by val_id\n    LIMIT 100",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -4052,7 +4071,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -4140,8 +4160,8 @@
       {
         "current": {
           "selected": false,
-          "text": "167399",
-          "value": "167399"
+          "text": "170501",
+          "value": "170501"
         },
         "datasource": {
           "type": "prometheus",
@@ -4168,8 +4188,8 @@
       {
         "current": {
           "selected": false,
-          "text": "10",
-          "value": "10"
+          "text": "0",
+          "value": "0"
         },
         "datasource": {
           "type": "prometheus",
@@ -4268,8 +4288,8 @@
       {
         "current": {
           "selected": false,
-          "text": "96.038818359375",
-          "value": "96.038818359375"
+          "text": "95.4833984375",
+          "value": "95.4833984375"
         },
         "datasource": {
           "type": "prometheus",
@@ -4333,6 +4353,6 @@
   "timezone": "",
   "title": "NodeOperators",
   "uid": "3wimU2H7h",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/docker/grafana/provisioning/dashboards/validators.json
+++ b/docker/grafana/provisioning/dashboards/validators.json
@@ -24,8 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 15,
-  "iteration": 1671105774080,
+  "iteration": 1672295458681,
   "links": [
     {
       "asDropdown": false,
@@ -2755,7 +2754,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "semi-dark-green"
+                "color": "semi-dark-green",
+                "value": null
               }
             ]
           }
@@ -2926,7 +2926,7 @@
           }
         ]
       },
-      "pluginVersion": "8.5.13",
+      "pluginVersion": "8.5.15",
       "targets": [
         {
           "datasource": {
@@ -3466,7 +3466,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               },
@@ -3544,7 +3545,8 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "yellow",
@@ -3595,7 +3597,7 @@
             "showUnfilled": true,
             "text": {}
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
               "datasource": {
@@ -3661,7 +3663,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -3737,7 +3740,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -3827,7 +3831,7 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
               "datasource": {
@@ -3839,8 +3843,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "SELECT\n  current.val_balance - previous.val_balance AS GWei,\n  current.val_nos_name as Operator,\n  current.val_id as Validator\nFROM \n  (\n    SELECT val_balance, val_id, val_nos_id, val_nos_name \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = ${epoch_number_var}\n  ) AS current\nLEFT JOIN\n  (\n    SELECT val_balance, val_id, val_nos_id, val_nos_name \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = ${epoch_number_var} - 6\n  ) AS previous\nON\n  previous.val_nos_id = current.val_nos_id AND \n  previous.val_id = current.val_id\nORDER BY GWei ASC\nLIMIT 100",
-              "rawQuery": "SELECT\n  current.val_balance - previous.val_balance AS GWei,\n  current.val_nos_name as Operator,\n  current.val_id as Validator\nFROM \n  (\n    SELECT val_balance, val_id, val_nos_id, val_nos_name \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = 161306\n  ) AS current\nLEFT JOIN\n  (\n    SELECT val_balance, val_id, val_nos_id, val_nos_name \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = 161306 - 6\n  ) AS previous\nON\n  previous.val_nos_id = current.val_nos_id AND \n  previous.val_id = current.val_id\nORDER BY GWei ASC\nLIMIT 100",
+              "query": "SELECT\n  current.val_balance - previous.val_balance AS GWei,\n  current.val_nos_name as Operator,\n  current.val_id as Validator\nFROM \n  (\n    SELECT val_balance, val_id, val_nos_id, val_nos_name \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = ${epoch_number_var}\n    LIMIT 1 by val_id\n  ) AS current\nLEFT JOIN\n  (\n    SELECT val_balance, val_id, val_nos_id, val_nos_name \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = ${epoch_number_var} - 6\n    LIMIT 1 by val_id\n  ) AS previous\nON\n  previous.val_nos_id = current.val_nos_id AND \n  previous.val_id = current.val_id\nORDER BY GWei ASC\nLIMIT 100",
+              "rawQuery": "SELECT\n  current.val_balance - previous.val_balance AS GWei,\n  current.val_nos_name as Operator,\n  current.val_id as Validator\nFROM \n  (\n    SELECT val_balance, val_id, val_nos_id, val_nos_name \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = 170495\n    LIMIT 1 by val_id\n  ) AS current\nLEFT JOIN\n  (\n    SELECT val_balance, val_id, val_nos_id, val_nos_name \n    FROM validators_summary \n    WHERE \n      val_status != 'pending_queued' AND \n      val_nos_id IS NOT NULL AND\n      epoch = 170495 - 6\n    LIMIT 1 by val_id\n  ) AS previous\nON\n  previous.val_nos_id = current.val_nos_id AND \n  previous.val_id = current.val_id\nORDER BY GWei ASC\nLIMIT 100",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -3893,7 +3897,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -3993,7 +3998,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -4085,7 +4091,7 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
               "datasource": {
@@ -4097,8 +4103,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "SELECT\n  block_to_propose as Block,\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE is_proposer = 1 AND val_nos_id IS NOT NULL AND block_proposed = 0 AND (epoch <= ${epoch_number_var} AND epoch >= (${epoch_number_var} - ${epochs_range}))\nORDER BY block_to_propose DESC, val_id",
-              "rawQuery": "SELECT\n  block_to_propose as Block,\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE is_proposer = 1 AND val_nos_id IS NOT NULL AND block_proposed = 0 AND (epoch <= 161306 AND epoch >= (161306 - 20))\nORDER BY block_to_propose DESC, val_id",
+              "query": "SELECT\n  block_to_propose as Block,\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE is_proposer = 1 AND val_nos_id IS NOT NULL AND block_proposed = 0 AND (epoch <= ${epoch_number_var} AND epoch >= (${epoch_number_var} - ${epochs_range}))\nORDER BY block_to_propose DESC, val_id\nLIMIT 1 by epoch, val_id",
+              "rawQuery": "SELECT\n  block_to_propose as Block,\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE is_proposer = 1 AND val_nos_id IS NOT NULL AND block_proposed = 0 AND (epoch <= 170497 AND epoch >= (170497 - 10))\nORDER BY block_to_propose DESC, val_id\nLIMIT 1 by epoch, val_id",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -4151,7 +4157,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -4263,7 +4270,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4433,7 +4441,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -4523,7 +4532,7 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
               "datasource": {
@@ -4535,8 +4544,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "SELECT\n    sync_percent as Percent,\n    val_nos_name as Operator,\n    val_id as Validator\nFROM\n    validators_summary\nWHERE is_sync = 1 AND val_nos_id IS NOT NULL AND epoch = ${epoch_number_var} AND sync_percent < (${chain_sync_avg_participation} - ${sync_participation_distance_var})\nORDER BY sync_percent",
-              "rawQuery": "SELECT\n    sync_percent as Percent,\n    val_nos_name as Operator,\n    val_id as Validator\nFROM\n    validators_summary\nWHERE is_sync = 1 AND val_nos_id IS NOT NULL AND epoch = 161306 AND sync_percent < (97.59954616427422 - 10)\nORDER BY sync_percent",
+              "query": "SELECT\n    sync_percent as Percent,\n    val_nos_name as Operator,\n    val_id as Validator\nFROM\n    validators_summary\nWHERE is_sync = 1 AND val_nos_id IS NOT NULL AND epoch = ${epoch_number_var} AND sync_percent < (${chain_sync_avg_participation} - ${sync_participation_distance_var})\nORDER BY sync_percent\nLIMIT 1 by epoch, val_id",
+              "rawQuery": "SELECT\n    sync_percent as Percent,\n    val_nos_name as Operator,\n    val_id as Validator\nFROM\n    validators_summary\nWHERE is_sync = 1 AND val_nos_id IS NOT NULL AND epoch = 170497 AND sync_percent < (97.8271484375 - 0)\nORDER BY sync_percent\nLIMIT 1 by epoch, val_id",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -4589,7 +4598,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -4710,7 +4720,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -4800,7 +4811,7 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
               "datasource": {
@@ -4812,8 +4823,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_happened = 0 AND val_nos_id IS NOT NULL AND epoch = ${epoch_number_var}\nORDER BY val_id\nLIMIT 100",
-              "rawQuery": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_happened = 0 AND val_nos_id IS NOT NULL AND epoch = 164438\nORDER BY val_id\nLIMIT 100",
+              "query": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_happened = 0 AND val_nos_id IS NOT NULL AND epoch = ${epoch_number_var}\nORDER BY val_id\nLIMIT 1 by val_id\nLIMIT 100",
+              "rawQuery": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_happened = 0 AND val_nos_id IS NOT NULL AND epoch = 170497\nORDER BY val_id\nLIMIT 1 by val_id\nLIMIT 100",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -4866,7 +4877,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -4970,7 +4982,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -5060,7 +5073,7 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
               "datasource": {
@@ -5072,8 +5085,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_happened = 1 AND att_inc_delay > 1 AND val_nos_id IS NOT NULL AND epoch = ${epoch_number_var}\nORDER BY val_id\nLIMIT 100",
-              "rawQuery": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_happened = 1 AND att_inc_delay > 1 AND val_nos_id IS NOT NULL AND epoch = 164441\nORDER BY val_id\nLIMIT 100",
+              "query": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_happened = 1 AND att_inc_delay > 1 AND val_nos_id IS NOT NULL AND epoch = ${epoch_number_var}\nORDER BY val_id\nLIMIT 1 by val_id\nLIMIT 100",
+              "rawQuery": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_happened = 1 AND att_inc_delay > 1 AND val_nos_id IS NOT NULL AND epoch = 170497\nORDER BY val_id\nLIMIT 1 by val_id\nLIMIT 100",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -5126,7 +5139,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -5229,7 +5243,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -5319,7 +5334,7 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
               "datasource": {
@@ -5331,8 +5346,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_valid_head = 0 AND val_nos_id IS NOT NULL AND epoch = ${epoch_number_var}\nORDER BY val_id\nLIMIT 100",
-              "rawQuery": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_valid_head = 0 AND val_nos_id IS NOT NULL AND epoch = 164441\nORDER BY val_id\nLIMIT 100",
+              "query": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_valid_head = 0 AND val_nos_id IS NOT NULL AND epoch = ${epoch_number_var}\nORDER BY val_id\nLIMIT 1 by val_id\nLIMIT 100",
+              "rawQuery": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_valid_head = 0 AND val_nos_id IS NOT NULL AND epoch = 170497\nORDER BY val_id\nLIMIT 1 by val_id\nLIMIT 100",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -5385,7 +5400,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -5488,7 +5504,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -5578,7 +5595,7 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
               "datasource": {
@@ -5591,7 +5608,7 @@
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
               "query": "\nSELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_valid_target = 0 AND val_nos_id IS NOT NULL AND epoch = ${epoch_number_var}\nORDER BY val_id\nLIMIT 100",
-              "rawQuery": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_valid_target = 0 AND val_nos_id IS NOT NULL AND epoch = 164441\nORDER BY val_id\nLIMIT 100",
+              "rawQuery": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_valid_target = 0 AND val_nos_id IS NOT NULL AND epoch = 170497\nORDER BY val_id\nLIMIT 100",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -5644,7 +5661,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -5747,7 +5765,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -5837,7 +5856,7 @@
               }
             ]
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
               "datasource": {
@@ -5849,8 +5868,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "\nSELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_valid_source = 0 AND val_nos_id IS NOT NULL AND epoch = ${epoch_number_var}\nORDER BY val_id\nLIMIT 100",
-              "rawQuery": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_valid_source = 0 AND val_nos_id IS NOT NULL AND epoch = 164441\nORDER BY val_id\nLIMIT 100",
+              "query": "\nSELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_valid_source = 0 AND val_nos_id IS NOT NULL AND epoch = ${epoch_number_var}\nORDER BY val_id\nLIMIT 1 by val_id\nLIMIT 100",
+              "rawQuery": "SELECT\n  val_nos_name as Operator,\n  val_id as Validator\nFROM validators_summary\nWHERE att_valid_source = 0 AND val_nos_id IS NOT NULL AND epoch = 170497\nORDER BY val_id\nLIMIT 1 by val_id\nLIMIT 100",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -5903,7 +5922,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -5988,7 +6008,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6041,7 +6062,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 124
+            "y": 62
           },
           "id": 51,
           "options": {
@@ -6055,7 +6076,7 @@
             },
             "showHeader": true
           },
-          "pluginVersion": "8.5.13",
+          "pluginVersion": "8.5.15",
           "targets": [
             {
               "datasource": {
@@ -6067,8 +6088,8 @@
               "format": "table",
               "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
               "intervalFactor": 1,
-              "query": "SELECT\n    val_nos_name as Operator,\n    val_id as Validator\nFROM validators_summary\nWHERE (val_status == 'active_slashed' OR val_status == 'exited_slashed' OR val_slashed == 1) AND val_nos_id IS NOT NULL and epoch = ${epoch_number_var}",
-              "rawQuery": "SELECT\n    val_nos_name as Operator,\n    val_id as Validator\nFROM validators_summary\nWHERE (val_status == 'active_slashed' OR val_status == 'exited_slashed' OR val_slashed == 1) AND val_nos_id IS NOT NULL and epoch = 161306",
+              "query": "SELECT\n    val_nos_name as Operator,\n    val_id as Validator\nFROM validators_summary\nWHERE (val_status == 'active_slashed' OR val_status == 'exited_slashed' OR val_slashed == 1) AND val_nos_id IS NOT NULL and epoch = ${epoch_number_var}\nLIMIT 1 by val_id",
+              "rawQuery": "SELECT\n    val_nos_name as Operator,\n    val_id as Validator\nFROM validators_summary\nWHERE (val_status == 'active_slashed' OR val_status == 'exited_slashed' OR val_slashed == 1) AND val_nos_id IS NOT NULL and epoch = 170497\nLIMIT 1 by val_id",
               "refId": "A",
               "round": "0s",
               "skip_comments": true
@@ -6141,7 +6162,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -6241,7 +6263,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -6304,8 +6327,8 @@
       {
         "current": {
           "selected": false,
-          "text": "167397",
-          "value": "167397"
+          "text": "170497",
+          "value": "170497"
         },
         "datasource": {
           "type": "prometheus",
@@ -6332,8 +6355,8 @@
       {
         "current": {
           "selected": false,
-          "text": "10",
-          "value": "10"
+          "text": "0",
+          "value": "0"
         },
         "datasource": {
           "type": "prometheus",
@@ -6360,8 +6383,8 @@
       {
         "current": {
           "selected": false,
-          "text": "97.79052734375",
-          "value": "97.79052734375"
+          "text": "97.8271484375",
+          "value": "97.8271484375"
         },
         "datasource": {
           "type": "prometheus",
@@ -6388,8 +6411,8 @@
       {
         "current": {
           "selected": false,
-          "text": "10",
-          "value": "10"
+          "text": "9",
+          "value": "9"
         },
         "datasource": {
           "type": "prometheus",
@@ -6432,6 +6455,6 @@
   "timezone": "",
   "title": "Validators",
   "uid": "HRgPmpNnz",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/src/duty/duty.metrics.ts
+++ b/src/duty/duty.metrics.ts
@@ -5,6 +5,7 @@ import { ConfigService } from 'common/config';
 import { ConsensusProviderService } from 'common/eth-providers';
 import { PrometheusService, TrackTask } from 'common/prometheus';
 
+import { ClickhouseService } from '../storage';
 import { AttestationMetrics } from './attestation';
 import { ProposeMetrics } from './propose';
 import { StateMetrics } from './state';
@@ -24,6 +25,7 @@ export class DutyMetrics {
     protected readonly proposeMetrics: ProposeMetrics,
     protected readonly syncMetrics: SyncMetrics,
     protected readonly summaryMetrics: SummaryMetrics,
+    protected readonly storage: ClickhouseService,
   ) {}
 
   @TrackTask('calc-all-duties-metrics')
@@ -32,6 +34,7 @@ export class DutyMetrics {
     await Promise.all([this.withPossibleHighReward(epoch, possibleHighRewardValidators), this.stateMetrics.calculate(epoch)]);
     // we must calculate summary metrics after all duties to avoid errors in processing
     await this.summaryMetrics.calculate(epoch);
+    await this.storage.updateEpochProcessing({ epoch, is_calculated: true });
   }
 
   private async withPossibleHighReward(epoch: bigint, possibleHighRewardValidators: string[]): Promise<void> {

--- a/src/duty/duty.service.ts
+++ b/src/duty/duty.service.ts
@@ -45,8 +45,9 @@ export class DutyService {
       this.checkAll(epoch, stateSlot),
       this.getPossibleHighRewardValidators(),
     ]);
-    await this.writeSummary();
     await this.writeEpochMeta(epoch);
+    await this.writeSummary();
+    await this.storage.updateEpochProcessing({ epoch, is_stored: true });
     return possibleHighRewardVals;
   }
 

--- a/src/duty/summary/summary.metrics.ts
+++ b/src/duty/summary/summary.metrics.ts
@@ -26,7 +26,7 @@ export class SummaryMetrics {
     protected readonly storage: ClickhouseService,
   ) {}
 
-  @TrackTask('calc-state-metrics')
+  @TrackTask('calc-summary-metrics')
   public async calculate(epoch: bigint) {
     this.logger.log('Calculating propose metrics');
     this.processedEpoch = epoch;

--- a/src/inspector/inspector.service.ts
+++ b/src/inspector/inspector.service.ts
@@ -6,14 +6,13 @@ import { ConfigService } from 'common/config';
 import { BlockHeaderResponse, ConsensusProviderService } from 'common/eth-providers';
 import { BlockCacheService } from 'common/eth-providers/consensus-provider/block-cache';
 import { sleep } from 'common/functions/sleep';
-import { PrometheusService } from 'common/prometheus';
+import { PrometheusService, TrackTask } from 'common/prometheus';
 import { DutyMetrics, DutyService } from 'duty';
 import { ClickhouseService } from 'storage';
+import { EpochProcessingState } from 'storage/clickhouse';
 
 @Injectable()
 export class InspectorService implements OnModuleInit {
-  public latestProcessedEpoch = 0n;
-
   public constructor(
     @Inject(LOGGER_PROVIDER) protected readonly logger: LoggerService,
     protected readonly config: ConfigService,
@@ -29,9 +28,9 @@ export class InspectorService implements OnModuleInit {
 
   public async onModuleInit(): Promise<void> {
     this.logger.log(`Starting epoch [${this.config.get('START_EPOCH')}]`);
-    this.latestProcessedEpoch = await this.storage.getMaxEpoch();
-    this.prometheus.epochTime = await this.clClient.getSlotTime(this.latestProcessedEpoch * 32n);
-    this.prometheus.epochNumber.set(Number(this.latestProcessedEpoch));
+    const latestProcessedEpoch = await this.storage.getLastProcessedEpoch();
+    this.prometheus.epochTime = await this.clClient.getSlotTime(latestProcessedEpoch.epoch * 32n);
+    this.prometheus.epochNumber.set(Number(latestProcessedEpoch.epoch));
   }
 
   public async startLoop(): Promise<never> {
@@ -41,13 +40,17 @@ export class InspectorService implements OnModuleInit {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       try {
-        const nextFinalized = await this.waitForNextFinalizedSlot();
-        if (nextFinalized) {
-          const { epoch, stateSlot } = nextFinalized;
-          const possibleHighRewardValidators = await this.dutyService.checkAndWrite(epoch, stateSlot);
-          await this.dutyMetrics.calculate(epoch, possibleHighRewardValidators);
+        const toProcess = await this.getEpochDataToProcess();
+        if (toProcess) {
+          const { epoch, slot, is_stored, is_calculated } = toProcess;
+          let possibleHighRewardValidators = [];
+          if (!is_stored) {
+            possibleHighRewardValidators = await this.dutyService.checkAndWrite(epoch, slot);
+          }
+          if (!is_calculated) {
+            await this.dutyMetrics.calculate(epoch, possibleHighRewardValidators);
+          }
           await this.criticalAlerts.send(epoch);
-          this.latestProcessedEpoch = epoch;
         }
       } catch (e) {
         this.logger.error(`Error while processing and writing epoch`);
@@ -65,16 +68,16 @@ export class InspectorService implements OnModuleInit {
     }
   }
 
-  protected async waitForNextFinalizedSlot(): Promise<{ epoch: bigint; stateSlot: bigint } | undefined> {
-    const nextSlot = this.calculateNextFinalizedSlot();
+  protected async getEpochDataToProcess(): Promise<EpochProcessingState & { slot: bigint }> {
+    const chosen = await this.chooseEpochToProcess();
     const latestFinalizedBeaconBlock = <BlockHeaderResponse>await this.clClient.getBlockHeader('finalized');
     const latestFinalizedEpoch = BigInt(latestFinalizedBeaconBlock.header.message.slot) / 32n;
-    if (BigInt(latestFinalizedBeaconBlock.header.message.slot) < nextSlot) {
-      // new finalized slot hasn't happened, from which we should get information about needed
+    if (latestFinalizedEpoch < chosen.epoch) {
+      // new finalized epoch hasn't happened, from which we should get information about needed
       // just wait `CHAIN_SLOT_TIME_SECONDS` until finality happens
       const sleepTime = this.config.get('CHAIN_SLOT_TIME_SECONDS');
       this.logger.log(
-        `Latest finalized epoch [${latestFinalizedEpoch}] found. Latest DB epoch [${this.latestProcessedEpoch}]. Waiting [${sleepTime}] seconds for next finalized slot [${nextSlot}]`,
+        `Latest finalized epoch [${latestFinalizedEpoch}]. Waiting [${sleepTime}] seconds for next finalized epoch [${chosen.epoch}]`,
       );
 
       return new Promise((resolve) => {
@@ -82,38 +85,40 @@ export class InspectorService implements OnModuleInit {
       });
     }
     // new finalized slot has happened, from which we can get information about needed
-    this.logger.log(
-      `Latest finalized epoch [${latestFinalizedEpoch}] found. Next slot [${nextSlot}]. Latest DB epoch [${this.latestProcessedEpoch}]`,
-    );
-
-    const nextProcessedEpoch = nextSlot / 32n;
-    const nextProcessedHeader = await this.clClient.getBeaconBlockHeaderOrPreviousIfMissed(nextSlot);
-    if (nextSlot == BigInt(nextProcessedHeader.header.message.slot)) {
+    this.logger.log(`Latest finalized epoch [${latestFinalizedEpoch}]. Next epoch to process [${chosen.epoch}]`);
+    const existedHeader = (await this.clClient.getBeaconBlockHeaderOrPreviousIfMissed(chosen.slot)).header.message;
+    if (chosen.slot == BigInt(existedHeader.slot)) {
       this.logger.log(
-        `Fetched next epoch [${nextProcessedEpoch}] by slot [${nextSlot}] with state root [${nextProcessedHeader.header.message.state_root}]`,
+        `Epoch [${chosen.epoch}] is chosen to process with state slot [${chosen.slot}] with root [${existedHeader.state_root}]`,
       );
     } else {
       this.logger.log(
-        `Fetched next epoch [${nextProcessedEpoch}] by slot [${nextProcessedHeader.header.message.slot}] with state root [${
-          nextProcessedHeader.header.message.state_root
-        }] instead of slot [${nextSlot}]. Difference [${BigInt(nextProcessedHeader.header.message.slot) - nextSlot}] slots`,
+        `Epoch [${chosen.epoch}] is chosen to process with state slot [${existedHeader.slot}] with root [${existedHeader.state_root}] ` +
+          `instead of slot [${chosen.slot}]. Difference [${BigInt(existedHeader.slot) - chosen.slot}] slots`,
       );
     }
 
     return {
-      epoch: nextProcessedEpoch,
-      stateSlot: nextProcessedHeader.header.message.slot,
+      ...chosen,
+      slot: existedHeader.slot,
     };
   }
 
-  protected calculateNextFinalizedSlot(): bigint {
-    const step = BigInt(this.config.get('FETCH_INTERVAL_SLOTS'));
-    let startEpoch = BigInt(this.config.get('START_EPOCH'));
-    if (this.latestProcessedEpoch >= startEpoch) {
-      startEpoch = this.latestProcessedEpoch + 1n;
+  @TrackTask('choose-epoch-to-process')
+  protected async chooseEpochToProcess(): Promise<EpochProcessingState & { slot: bigint }> {
+    let next: EpochProcessingState = { epoch: BigInt(this.config.get('START_EPOCH')), is_stored: false, is_calculated: false };
+    const last = await this.storage.getLastEpoch();
+    const lastProcessed = await this.storage.getLastProcessedEpoch();
+    this.logger.log(`Last processed epoch [${lastProcessed.epoch}]`);
+    if ((last.is_stored && !last.is_calculated) || (!last.is_stored && last.is_calculated)) {
+      this.logger.debug(JSON.stringify(last));
+      this.logger.warn(`Epoch [${last.epoch}] processing was not completed correctly. Trying to complete`);
+      next = last;
     }
-    const slotToProcess = startEpoch * step + (step - 1n); // latest slot in epoch
-    this.logger.log(`Slot to process [${slotToProcess}] (end of epoch [${startEpoch}])`);
-    return slotToProcess;
+    if (lastProcessed.epoch >= next.epoch) {
+      next.epoch = lastProcessed.epoch + 1n;
+      this.logger.log(`Next epoch to process [${next.epoch}]`);
+    }
+    return { ...next, slot: next.epoch * 32n };
   }
 }

--- a/src/inspector/inspector.service.ts
+++ b/src/inspector/inspector.service.ts
@@ -106,6 +106,7 @@ export class InspectorService implements OnModuleInit {
 
   @TrackTask('choose-epoch-to-process')
   protected async chooseEpochToProcess(): Promise<EpochProcessingState & { slot: bigint }> {
+    const step = BigInt(this.config.get('FETCH_INTERVAL_SLOTS'));
     let next: EpochProcessingState = { epoch: BigInt(this.config.get('START_EPOCH')), is_stored: false, is_calculated: false };
     const last = await this.storage.getLastEpoch();
     const lastProcessed = await this.storage.getLastProcessedEpoch();
@@ -119,6 +120,6 @@ export class InspectorService implements OnModuleInit {
       next.epoch = lastProcessed.epoch + 1n;
       this.logger.log(`Next epoch to process [${next.epoch}]`);
     }
-    return { ...next, slot: next.epoch * 32n };
+    return { ...next, slot: next.epoch * step + (step - 1n) };
   }
 }

--- a/src/storage/clickhouse/clickhouse.constants.ts
+++ b/src/storage/clickhouse/clickhouse.constants.ts
@@ -111,7 +111,7 @@ export const validatorsCountWithSyncParticipationByConditionLastNEpochQuery = (
           ${condition} AND
           (epoch <= ${epoch} AND epoch > (${epoch} - ${epochInterval}))
           ${strFilterValIndexes}
-        LIMIT 1 BY val_id
+        LIMIT 1 BY epoch, val_id
       )
       GROUP BY val_id, val_nos_id
     )
@@ -145,7 +145,7 @@ export const validatorCountByConditionAttestationLastNEpochQuery = (
           ${condition}
           AND (epoch <= ${epoch} AND epoch > (${epoch} - ${epochInterval}))
           ${strFilterValIndexes}
-        LIMIT 1 BY val_id
+        LIMIT 1 BY epoch, val_id
       )
       GROUP BY val_id, val_nos_id
     )
@@ -168,7 +168,7 @@ export const validatorCountHighAvgIncDelayAttestationOfNEpochQuery = (epoch: big
         FROM validators_summary
         WHERE
           (epoch <= ${epoch} AND epoch > (${epoch} - ${epochInterval}))
-        LIMIT 1 BY val_id
+        LIMIT 1 BY epoch, val_id
       )
       GROUP BY val_id, val_nos_id
       HAVING avg_inclusion_delay > 2
@@ -194,7 +194,7 @@ export const validatorsCountByConditionMissProposeQuery = (epoch: bigint, valida
         ${condition} AND
         (epoch <= ${epoch} AND epoch > (${epoch} - 1))
         ${strFilterValIndexes}
-      LIMIT 1 BY val_id
+      LIMIT 1 BY epoch, val_id
     )
     GROUP BY val_nos_id
   `;
@@ -396,7 +396,7 @@ export const userNodeOperatorsProposesStatsLastNEpochQuery = (epoch: bigint, epo
       FROM validators_summary
       WHERE
         is_proposer = 1 AND (epoch <= ${epoch} AND epoch > (${epoch} - ${epochInterval}))
-      LIMIT 1 BY val_id
+      LIMIT 1 BY epoch, val_id
     )
     GROUP BY val_nos_id, block_proposed
   )

--- a/src/storage/clickhouse/clickhouse.constants.ts
+++ b/src/storage/clickhouse/clickhouse.constants.ts
@@ -12,6 +12,7 @@ export const avgValidatorBalanceDelta = (epoch: bigint): string => `
         val_status != '${ValStatus.PendingQueued}' AND
         val_nos_id IS NOT NULL AND
         epoch = ${epoch}
+      LIMIT 1 BY val_id
     ) AS current
   INNER JOIN
     (
@@ -39,6 +40,7 @@ export const validatorQuantile0001BalanceDeltasQuery = (epoch: bigint): string =
         val_status != '${ValStatus.PendingQueued}' AND
         val_nos_id IS NOT NULL AND
         epoch = ${epoch}
+      LIMIT 1 BY val_id
     ) AS current
   INNER JOIN
     (
@@ -66,6 +68,7 @@ export const validatorsCountWithNegativeDeltaQuery = (epoch: bigint): string => 
         val_status != '${ValStatus.PendingQueued}' AND
         val_nos_id IS NOT NULL AND
         epoch = ${epoch}
+      LIMIT 1 BY val_id
     ) AS current
   INNER JOIN
     (
@@ -108,6 +111,7 @@ export const validatorsCountWithSyncParticipationByConditionLastNEpochQuery = (
           ${condition} AND
           (epoch <= ${epoch} AND epoch > (${epoch} - ${epochInterval}))
           ${strFilterValIndexes}
+        LIMIT 1 BY val_id
       )
       GROUP BY val_id, val_nos_id
     )
@@ -141,6 +145,7 @@ export const validatorCountByConditionAttestationLastNEpochQuery = (
           ${condition}
           AND (epoch <= ${epoch} AND epoch > (${epoch} - ${epochInterval}))
           ${strFilterValIndexes}
+        LIMIT 1 BY val_id
       )
       GROUP BY val_id, val_nos_id
     )
@@ -163,6 +168,7 @@ export const validatorCountHighAvgIncDelayAttestationOfNEpochQuery = (epoch: big
         FROM validators_summary
         WHERE
           (epoch <= ${epoch} AND epoch > (${epoch} - ${epochInterval}))
+        LIMIT 1 BY val_id
       )
       GROUP BY val_id, val_nos_id
       HAVING avg_inclusion_delay > 2
@@ -188,6 +194,7 @@ export const validatorsCountByConditionMissProposeQuery = (epoch: bigint, valida
         ${condition} AND
         (epoch <= ${epoch} AND epoch > (${epoch} - 1))
         ${strFilterValIndexes}
+      LIMIT 1 BY val_id
     )
     GROUP BY val_nos_id
   `;
@@ -196,25 +203,37 @@ export const validatorsCountByConditionMissProposeQuery = (epoch: bigint, valida
 export const userSyncParticipationAvgPercentQuery = (epoch: bigint): string => `
   SELECT
     avg(sync_percent) as avg_percent
-  FROM validators_summary
-  WHERE
-    is_sync = 1 AND val_nos_id IS NOT NULL AND epoch = ${epoch}
+  FROM (
+    SELECT sync_percent
+    FROM validators_summary
+    WHERE
+      is_sync = 1 AND val_nos_id IS NOT NULL AND epoch = ${epoch}
+    LIMIT 1 BY val_id
+  )
 `;
 
 export const otherSyncParticipationAvgPercentQuery = (epoch: bigint): string => `
   SELECT
     avg(sync_percent) as avg_percent
-  FROM validators_summary
-  WHERE
-    is_sync = 1 AND val_nos_id IS NULL AND epoch = ${epoch}
+  FROM (
+    SELECT sync_percent
+    FROM validators_summary
+    WHERE
+      is_sync = 1 AND val_nos_id IS NULL AND epoch = ${epoch}
+    LIMIT 1 BY val_id
+  )
 `;
 
 export const chainSyncParticipationAvgPercentQuery = (epoch: bigint): string => `
   SELECT
     avg(sync_percent) as avg_percent
-  FROM validators_summary
-  WHERE
-    is_sync = 1 AND epoch = ${epoch}
+  FROM (
+    SELECT sync_percent
+    FROM validators_summary
+    WHERE
+      is_sync = 1 AND epoch = ${epoch}
+    LIMIT 1 BY val_id
+  )
 `;
 
 export const operatorsSyncParticipationAvgPercentsQuery = (epoch: bigint): string => `
@@ -226,6 +245,7 @@ export const operatorsSyncParticipationAvgPercentsQuery = (epoch: bigint): strin
     FROM validators_summary
     WHERE
       is_sync = 1 AND val_nos_id IS NOT NULL AND epoch = ${epoch}
+    LIMIT 1 BY val_id
   )
   GROUP BY val_nos_id
 `;
@@ -233,8 +253,15 @@ export const operatorsSyncParticipationAvgPercentsQuery = (epoch: bigint): strin
 export const totalBalance24hDifferenceQuery = (epoch: bigint): string => `
   SELECT (
     SELECT SUM(curr.val_balance)
-    FROM
-      validators_summary AS curr
+    FROM (
+      SELECT val_balance, val_id, val_nos_id
+      FROM validators_summary
+      WHERE
+        epoch = ${epoch}
+        AND val_status != '${ValStatus.PendingQueued}'
+        AND val_nos_id IS NOT NULL
+      LIMIT 1 BY val_id
+    ) AS curr
     INNER JOIN (
       SELECT val_balance, val_id, val_nos_id
       FROM validators_summary
@@ -246,10 +273,6 @@ export const totalBalance24hDifferenceQuery = (epoch: bigint): string => `
     ON
       previous.val_nos_id = curr.val_nos_id AND
       previous.val_id = curr.val_id
-    WHERE
-      curr.epoch = ${epoch}
-      AND curr.val_status != '${ValStatus.PendingQueued}'
-      AND curr.val_nos_id IS NOT NULL
   ) as curr_total_balance,
   (
     SELECT SUM(prev.val_balance)
@@ -266,8 +289,15 @@ export const operatorBalance24hDifferenceQuery = (epoch: bigint): string => `
   SELECT
     curr.val_nos_id as val_nos_id,
     SUM(curr.val_balance - previous.val_balance) as diff
-  FROM
-    validators_summary AS curr
+  FROM (
+    SELECT val_balance, val_id, val_nos_id
+    FROM validators_summary
+    WHERE
+      epoch = ${epoch}
+      AND val_status != '${ValStatus.PendingQueued}'
+      AND val_nos_id IS NOT NULL
+    LIMIT 1 BY val_id
+  ) as curr
   INNER JOIN (
     SELECT val_balance, val_id, val_nos_id
     FROM validators_summary
@@ -279,10 +309,6 @@ export const operatorBalance24hDifferenceQuery = (epoch: bigint): string => `
   ON
     previous.val_nos_id = curr.val_nos_id AND
     previous.val_id = curr.val_id
-  WHERE
-    curr.epoch = ${epoch}
-    AND curr.val_status != '${ValStatus.PendingQueued}'
-    AND curr.val_nos_id IS NOT NULL
   GROUP BY curr.val_nos_id
 `;
 
@@ -303,6 +329,7 @@ export const userNodeOperatorsStatsQuery = (epoch: bigint): string => `
       FROM validators_summary
       WHERE
         val_nos_id IS NOT NULL and epoch = ${epoch}
+      LIMIT 1 BY val_id
     )
     GROUP BY val_nos_id, val_status, val_slashed
   )
@@ -320,9 +347,13 @@ export const userValidatorsSummaryStatsQuery = (epoch: bigint): string => `
       IF(val_status = '${ValStatus.ActiveOngoing}', count(val_status), 0) as a,
       IF(val_status = '${ValStatus.PendingQueued}' OR val_status = '${ValStatus.PendingInitialized}', count(val_status), 0) as p,
       IF(val_status = '${ValStatus.ActiveSlashed}' OR val_status = '${ValStatus.ExitedSlashed}' OR val_slashed = 1, count(val_status), 0) as s
-    FROM validators_summary
-    WHERE
-      val_nos_id IS NOT NULL and epoch = ${epoch}
+    FROM (
+      SELECT val_status, val_slashed
+      FROM validators_summary
+      WHERE
+        val_nos_id IS NOT NULL and epoch = ${epoch}
+      LIMIT 1 BY val_id
+    )
     GROUP BY val_status, val_slashed
   )
 `;
@@ -338,9 +369,13 @@ export const otherValidatorsSummaryStatsQuery = (epoch: bigint): string => `
       IF(val_status = '${ValStatus.ActiveOngoing}', count(val_status), 0) as a,
       IF(val_status = '${ValStatus.PendingQueued}' OR val_status = '${ValStatus.PendingInitialized}', count(val_status), 0) as p,
       IF(val_status = '${ValStatus.ActiveSlashed}' OR val_status = '${ValStatus.ExitedSlashed}' OR val_slashed = 1, count(val_status), 0) as s
-    FROM validators_summary
-    WHERE
-      val_nos_id IS NULL and epoch = ${epoch}
+    FROM (
+      SELECT val_status, val_slashed
+      FROM validators_summary
+      WHERE
+        val_nos_id IS NULL and epoch = ${epoch}
+      LIMIT 1 BY val_id
+    )
     GROUP BY val_status, val_slashed
   )
 `;
@@ -361,6 +396,7 @@ export const userNodeOperatorsProposesStatsLastNEpochQuery = (epoch: bigint, epo
       FROM validators_summary
       WHERE
         is_proposer = 1 AND (epoch <= ${epoch} AND epoch > (${epoch} - ${epochInterval}))
+      LIMIT 1 BY val_id
     )
     GROUP BY val_nos_id, block_proposed
   )
@@ -370,6 +406,12 @@ export const userNodeOperatorsProposesStatsLastNEpochQuery = (epoch: bigint, epo
 export const epochMetadata = (epoch: bigint): string => `
   SELECT *
   FROM epochs_metadata
+  WHERE epoch = ${epoch}
+`;
+
+export const epochProcessing = (epoch: bigint): string => `
+  SELECT *
+  FROM epochs_processing
   WHERE epoch = ${epoch}
 `;
 
@@ -400,8 +442,12 @@ export const userNodeOperatorsRewardsAndPenaltiesStats = (epoch: bigint): string
       sum(att_earned_reward) as attestation_reward,
       sum(att_missed_reward) as attestation_missed,
       sum(att_penalty) as attestation_penalty
-    FROM validators_summary
-    WHERE val_nos_id IS NOT NULL and epoch = ${epoch} - 2
+    FROM (
+      SELECT val_nos_id, att_earned_reward, att_missed_reward, att_penalty
+      FROM validators_summary
+      WHERE val_nos_id IS NOT NULL and epoch = ${epoch} - 2
+      LIMIT 1 BY val_id
+    )
     GROUP BY val_nos_id
   ) as att
   LEFT JOIN
@@ -411,8 +457,12 @@ export const userNodeOperatorsRewardsAndPenaltiesStats = (epoch: bigint): string
       sum(propose_earned_reward) as prop_reward,
       sum(propose_missed_reward) as prop_missed,
       sum(propose_penalty) as prop_penalty
-    FROM validators_summary
-    WHERE val_nos_id IS NOT NULL and epoch = ${epoch} and is_proposer = 1
+    FROM (
+      SELECT val_nos_id, propose_earned_reward, propose_missed_reward, propose_penalty
+      FROM validators_summary
+      WHERE val_nos_id IS NOT NULL and epoch = ${epoch} and is_proposer = 1
+      LIMIT 1 BY val_id
+    )
     GROUP BY val_nos_id
 	) as prop ON att.val_nos_id = prop.val_nos_id
   LEFT JOIN
@@ -422,8 +472,12 @@ export const userNodeOperatorsRewardsAndPenaltiesStats = (epoch: bigint): string
       sum(sync_earned_reward) as sync_reward,
       sum(sync_missed_reward) as sync_missed,
       sum(sync_penalty) as sync_penalty
-    FROM validators_summary
-    WHERE val_nos_id IS NOT NULL and epoch = ${epoch} and is_sync = 1
+    FROM (
+      SELECT val_nos_id, sync_earned_reward, sync_missed_reward, sync_penalty
+      FROM validators_summary
+      WHERE val_nos_id IS NOT NULL and epoch = ${epoch} and is_sync = 1
+      LIMIT 1 BY val_id
+    )
     GROUP BY val_nos_id
   ) as sync ON att.val_nos_id = sync.val_nos_id
   LEFT JOIN
@@ -438,6 +492,7 @@ export const userNodeOperatorsRewardsAndPenaltiesStats = (epoch: bigint): string
         val_status != '${ValStatus.PendingQueued}' AND
         val_nos_id IS NOT NULL AND
         epoch = ${epoch}
+      LIMIT 1 BY val_id
     ) AS current
     INNER JOIN
     (
@@ -447,6 +502,7 @@ export const userNodeOperatorsRewardsAndPenaltiesStats = (epoch: bigint): string
         val_status != '${ValStatus.PendingQueued}' AND
         val_nos_id IS NOT NULL AND
         epoch = (${epoch} - 1)
+      LIMIT 1 BY val_id
     ) AS previous ON previous.val_id = current.val_id
     GROUP BY val_nos_id
   ) as bal ON att.val_nos_id = bal.val_nos_id
@@ -469,23 +525,35 @@ export const avgChainRewardsAndPenaltiesStats = (epoch: bigint): string => `
       avg(att_earned_reward) as attestation_reward,
       avg(att_missed_reward) as attestation_missed,
       avg(att_penalty) as attestation_penalty
-    FROM validators_summary
-    WHERE epoch = ${epoch} - 2
+    FROM (
+      SELECT att_earned_reward, att_missed_reward, att_penalty
+      FROM validators_summary
+      WHERE epoch = ${epoch} - 2
+      LIMIT 1 BY val_id
+    )
   ) as att,
 	(
     SELECT
       avg(propose_earned_reward) as prop_reward,
       avg(propose_missed_reward) as prop_missed,
       avg(propose_penalty) as prop_penalty
-    FROM validators_summary
-    WHERE epoch = ${epoch} and is_proposer = 1
+    FROM (
+      SELECT propose_earned_reward, propose_missed_reward, propose_penalty
+      FROM validators_summary
+      WHERE epoch = ${epoch} and is_proposer = 1
+      LIMIT 1 BY val_id
+    )
 	) as prop,
   (
     SELECT
       avg(sync_earned_reward) as sync_reward,
       avg(sync_missed_reward) as sync_missed,
       avg(sync_penalty) as sync_penalty
-    FROM validators_summary
-    WHERE epoch = ${epoch} and is_sync = 1
+    FROM (
+      SELECT sync_earned_reward, sync_missed_reward, sync_penalty
+      FROM validators_summary
+      WHERE epoch = ${epoch} and is_sync = 1
+      LIMIT 1 BY val_id
+    )
   ) as sync
 `;

--- a/src/storage/clickhouse/clickhouse.types.ts
+++ b/src/storage/clickhouse/clickhouse.types.ts
@@ -78,3 +78,9 @@ export interface NOsProposesStats {
 export interface SyncCommitteeParticipationAvgPercents {
   avg_percent: number;
 }
+
+export interface EpochProcessingState {
+  epoch: bigint;
+  is_stored?: boolean;
+  is_calculated?: boolean;
+}

--- a/src/storage/clickhouse/migrations/migration_000002_rewards.ts
+++ b/src/storage/clickhouse/migrations/migration_000002_rewards.ts
@@ -1,5 +1,5 @@
 const sql = `
-ALTER TABLE stats.validators_summary
+ALTER TABLE validators_summary
 // state
 ADD COLUMN IF NOT EXISTS val_effective_balance Nullable(UInt64) AFTER val_balance,
 // att

--- a/src/storage/clickhouse/migrations/migration_000004_epoch_processing.ts
+++ b/src/storage/clickhouse/migrations/migration_000004_epoch_processing.ts
@@ -1,0 +1,10 @@
+const sql = `
+CREATE TABLE IF NOT EXISTS epochs_processing (
+    "epoch" Int64,
+    "is_stored" Nullable(UInt8),
+    "is_calculated" Nullable(UInt8)
+)
+ENGINE = ReplacingMergeTree()
+ORDER BY epoch
+`;
+export default sql;


### PR DESCRIPTION
In some cases where work of application may have been stopped (redeploy or some exceptional case), we can't be sure that two major tasks (saving data and calculating metrics) have been finished successfully.

To handle this, I propose these:

- add logic to complete of incomplete epoch processing
- add deduplication strategy to queries