### PR TITLE
fix: att participation rate

### DIFF
--- a/src/duty/duty.service.ts
+++ b/src/duty/duty.service.ts
@@ -109,7 +109,7 @@ export class DutyService {
       // Attestation participation calculated by previous epoch data
       // Sync part of proposal reward should be calculated from current epoch
       const attested = this.summary.epoch(epoch - 1).get(v.val_id);
-      if (attested?.att_happened) {
+      if (!v.val_slashed && attested?.att_happened) {
         if (attested.att_valid_source) {
           meta.attestation.participation.source += BigInt(increments);
         }


### PR DESCRIPTION
Slashed validator shouldn't affect participation. Otherwise, it will ruin all attestation rewards
Handling the case where proposer includes a found slashed attestation\proposal will be implemented in another PR 