### PR TITLE
fix: keys registry processing

### DIFF
--- a/src/common/validators-registry/lido-source/lido-source.service.ts
+++ b/src/common/validators-registry/lido-source/lido-source.service.ts
@@ -54,9 +54,12 @@ export class LidoSourceService implements RegistrySource {
   }
 
   protected async updateKeysMap() {
+    this.keysMap = new Map();
     for (const index of this.operatorsMap.keys()) {
       const operatorKeys = await this.keyStorageService.findByOperatorIndex(index);
-      this.keysMap = new Map(operatorKeys.map((k) => [k.key, k]));
+      for (const key of operatorKeys) {
+        this.keysMap.set(key.key, key);
+      }
       await unblock();
     }
   }

--- a/src/common/validators-registry/lido-source/lido-source.service.ts
+++ b/src/common/validators-registry/lido-source/lido-source.service.ts
@@ -58,7 +58,7 @@ export class LidoSourceService implements RegistrySource {
     for (const index of this.operatorsMap.keys()) {
       const operatorKeys = await this.keyStorageService.findByOperatorIndex(index);
       for (const key of operatorKeys) {
-        this.keysMap.set(key.key, key);
+        if (key.used) this.keysMap.set(key.key, key);
       }
       await unblock();
     }

--- a/src/common/validators-registry/lido-source/lido-source.service.ts
+++ b/src/common/validators-registry/lido-source/lido-source.service.ts
@@ -7,6 +7,7 @@ import {
 } from '@lido-nestjs/registry';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { unblock } from '../../functions/unblock';
 import { RegistrySource, RegistrySourceKey, RegistrySourceOperator } from '../registry-source.interface';
 
 @Injectable()
@@ -53,7 +54,10 @@ export class LidoSourceService implements RegistrySource {
   }
 
   protected async updateKeysMap() {
-    const allKeys = await this.keyStorageService.findUsed();
-    this.keysMap = new Map(allKeys.map((k) => [k.key, k]));
+    for (const index of this.operatorsMap.keys()) {
+      const operatorKeys = await this.keyStorageService.findByOperatorIndex(index);
+      this.keysMap = new Map(operatorKeys.map((k) => [k.key, k]));
+      await unblock();
+    }
   }
 }

--- a/src/common/validators-registry/registry-source.interface.ts
+++ b/src/common/validators-registry/registry-source.interface.ts
@@ -15,12 +15,9 @@ export interface RegistrySourceOperator {
   name: string;
 }
 
-export type RegistrySourceKeysIndexed = Map<string, RegistrySourceKeyWithOperatorName>;
-
 export interface RegistrySource {
   update(...args): Promise<void>;
-  getIndexedKeys(): Promise<RegistrySourceKeysIndexed | undefined>;
-  getKeys(): Promise<RegistrySourceKey[]>;
-  getOperators(): Promise<RegistrySourceOperator[]>;
+  getOperatorsMap(): Map<number, RegistrySourceOperator>;
+  getOperatorKey(pubKey: string): RegistrySourceKey | null;
   sourceTimestamp(): Promise<number>;
 }

--- a/src/common/validators-registry/registry.service.ts
+++ b/src/common/validators-registry/registry.service.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable, LoggerService } from '@nestjs/common';
 
 import { PrometheusService, TrackTask } from 'common/prometheus';
 
-import { REGISTRY_SOURCE, RegistrySource, RegistrySourceKeysIndexed } from './registry-source.interface';
+import { REGISTRY_SOURCE, RegistrySource, RegistrySourceKeyWithOperatorName } from './registry-source.interface';
 
 @Injectable()
 export class RegistryService {
@@ -13,41 +13,30 @@ export class RegistryService {
     protected readonly prometheus: PrometheusService,
   ) {}
 
-  public async getActualKeysIndexed(timestamp: number): Promise<RegistrySourceKeysIndexed | undefined> {
-    await this.updateValidators();
+  protected lastTimestamp = 0;
+
+  protected operators = [];
+
+  @TrackTask('update-validators')
+  public async updateKeysRegistry(timestamp: number): Promise<void> {
+    await this.source.update();
+    await this.updateTimestamp();
     if (timestamp > this.lastTimestamp) {
       const lastUpdateTime = new Date(this.lastTimestamp * 1000).toISOString();
       throw Error(`Validators registry data is too old. Last update - ${lastUpdateTime}`);
     }
-    return await this.source.getIndexedKeys();
+    this.operators = [...this.source.getOperatorsMap().values()];
   }
 
-  public async getOperators() {
-    return await this.source.getOperators();
+  public getOperatorKey(pubKey: string): RegistrySourceKeyWithOperatorName {
+    const key = this.source.getOperatorKey(pubKey);
+    if (!key) return null;
+    const operator = this.source.getOperatorsMap().get(key.operatorIndex);
+    return { ...key, operatorName: operator.name };
   }
 
-  protected lastTimestamp = 0;
-
-  /**
-   * Collects updates from source validators registry contract and saves the changes to the database
-   */
-  @TrackTask('update-validators')
-  protected async updateValidators(): Promise<void> {
-    try {
-      await this.source.update();
-      await this.updateTimestamp();
-    } catch (error) {
-      // Here we can get a timeout error or something else
-      this.logger.warn('Failed to update validators');
-      const curr = await this.source.getKeys();
-      if (curr?.length == 0) {
-        // throw error and run main cycle again
-        throw error;
-      } else {
-        // print error and continue to use current keys from storage
-        this.logger.error(error.error?.reason ?? error);
-      }
-    }
+  public getOperators() {
+    return this.operators;
   }
 
   /**

--- a/src/duty/state/state.service.ts
+++ b/src/duty/state/state.service.ts
@@ -31,7 +31,7 @@ export class StateService {
   @TrackTask('check-state-duties')
   public async check(epoch: Epoch, stateSlot: Slot): Promise<void> {
     const slotTime = await this.clClient.getSlotTime(epoch * this.config.get('FETCH_INTERVAL_SLOTS'));
-    const keysIndexed = await this.registry.getActualKeysIndexed(Number(slotTime));
+    await this.registry.updateKeysRegistry(Number(slotTime));
     this.logger.log('Getting all validators state');
     const readStream = await this.clClient.getValidatorsState(stateSlot);
     this.logger.log('Processing all validators state');
@@ -42,7 +42,7 @@ export class StateService {
       pipeline.on('data', async (data) => {
         const state: StateValidatorResponse = data.value;
         const index = Number(state.index);
-        const operator = keysIndexed.get(state.validator.pubkey);
+        const operator = this.registry.getOperatorKey(state.validator.pubkey);
         this.summary.epoch(epoch).set({
           epoch,
           val_id: index,

--- a/test/duties.e2e-spec.ts
+++ b/test/duties.e2e-spec.ts
@@ -151,7 +151,7 @@ describe('Duties', () => {
       }),
     );
   });
-  const getOperatorKeyMock = jest.fn().mockImplementation(async (key: string) => {
+  const getOperatorKeyMock = jest.fn().mockImplementation((key: string) => {
     return keysMap.get(key);
   });
   jest.spyOn(SimpleFallbackJsonRpcBatchProvider.prototype, 'detectNetwork').mockImplementation(async () => getNetwork('mainnet'));


### PR DESCRIPTION
We should update internal keys map only if keys from source registry (Lido contract) have been updated