### PR TITLE
clarify comments and defaults (#186)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,14 @@ DB_PORT=8123
 DB_HOST=http://clickhouse
 DB_USER=default
 DB_PASSWORD=
-DB_NAME=stats
+DB_NAME=default
 # Logs
 # log format can be 'simple' or 'json'
 LOG_FORMAT=simple
-# select a slot as close as possible to the last finalized: find last finalized epoch, copy last slot from it
+# select an epoch as close as possible to the last finalized.
+# you can find it here: 
+#  - https://beaconcha.in/epochs
+#  - https://beaconscan.com/epochs
 START_EPOCH=155000
 # you can set URL list (it must be a comma separated string)
 EL_RPC_URLS=https://<network_name>.infura.io/v3/<secret>


### PR DESCRIPTION
* clarify comments and defaults

* changed DB_NAME to default as that is the default when creating a ClickHouse database
* fixed a typo

* remove leading space from DB_NAME



* improve comment regarding finding a relevant epoch



* use 8123 (http) instead of 8443 (https) as it makes more sense for a local clickhouse instance

---------