### PR TITLE
fix: incorrect ports in `docker-compose`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,7 +171,7 @@ services:
     expose:
       - "${HTTP_PORT}"
     ports:
-      - "${EXTERNAL_HTTP_PORT:-${HTTP_PORT}}:${HTTP_PORT}"
+      - "${EXTERNAL_HTTP_PORT}:${HTTP_PORT}"
     volumes:
       - ./docker/validators/:/app/docker/validators
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,9 +169,9 @@ services:
       - EL_RPC_URLS=${EL_RPC_URLS}
       - CL_API_URLS=${CL_API_URLS}
     expose:
-      - "${HTTP_PORT}"
+      - "${HTTP_PORT:-8080}"
     ports:
-      - "${EXTERNAL_HTTP_PORT}:${HTTP_PORT}"
+      - "${EXTERNAL_HTTP_PORT:-${HTTP_PORT:-8080}}:${HTTP_PORT:-8080}"
     volumes:
       - ./docker/validators/:/app/docker/validators
     depends_on:


### PR DESCRIPTION
Pull Request #202 introduced a bug with port variables substitution in the `docker-compose.yml` file. Because of this bug clickhouse was not running correctly in a docker container. Now this bug is fixed.