### PR TITLE
fix: skip validation of `START_EPOCH` env variable

### DIFF
--- a/src/common/config/env.validation.ts
+++ b/src/common/config/env.validation.ts
@@ -160,7 +160,7 @@ export class EnvironmentVariables {
   @IsNumber()
   @Min(74240) // Altair
   @Transform(({ value }) => parseInt(value, 10), { toClassOnly: true })
-  @ValidateIf((vars) => vars.NODE_ENV != Environment.test && vars.ETH_NETWORK === Network.Mainnet)
+  @ValidateIf((vars) => vars.ETH_NETWORK === Network.Mainnet)
   public START_EPOCH = 155000;
 
   @IsNumber()

--- a/src/common/config/env.validation.ts
+++ b/src/common/config/env.validation.ts
@@ -160,6 +160,7 @@ export class EnvironmentVariables {
   @IsNumber()
   @Min(74240) // Altair
   @Transform(({ value }) => parseInt(value, 10), { toClassOnly: true })
+  @ValidateIf((vars) => vars.NODE_ENV != Environment.test && vars.ETH_NETWORK === Network.Mainnet)
   public START_EPOCH = 155000;
 
   @IsNumber()


### PR DESCRIPTION
As the Altair epoch is different in different testnets, it is not possible to set a static pre-defined number of the `START_EPOCH` as a required minimum value of this variable. So, for now, we skip the validation of this env variable on testnets.

Later it would be better to implement a custom validation directive for validating the minimum possible value of the `START_EPOCH` variable depending on the testnet where the application is running.