### PR TITLE
fix: temporarily increase space size

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/src/main --trace-warnings --sync --sub-fin-head",
+    "start:prod": "node dist/src/main --trace-warnings --sync --sub-fin-head --max-old-space-size=8192",
     "test": "jest --detectOpenHandles --forceExit",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",


### PR DESCRIPTION
Temporarily increase the `max-old-space-size` param to 8192 to test Holesky deployment.