### PR TITLE
chore: empty lines in sample env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,30 +8,30 @@ DB_PASSWORD=
 DB_NAME=default
 
 # Logs
-# log format can be 'simple' or 'json'
+# Log format can be "simple" or "json" (optional).
 LOG_FORMAT=simple
 
-# select an epoch as close as possible to the last finalized.
-# you can find it here:
+# Select an epoch as close as possible to the last finalized.
+# You can find it here:
 #  - https://beaconcha.in/epochs
 #  - https://beaconscan.com/epochs
 START_EPOCH=155000
 
-# execution layer network id (1 - mainnet, 5 - goerli)
+# Execution layer network id (1 - mainnet, 5 - goerli, 17000 - holesky).
 ETH_NETWORK=1
 
-# you can set URL list (it must be a comma separated string)
+# You can set URL list (it must be a comma separated string).
 EL_RPC_URLS=https://<network_name>.infura.io/v3/<secret>
 
-# you can set URL list (it must be a comma separated string)
+# You can set URL list (it must be a comma separated string).
 CL_API_URLS=https://<consensus-layer-api-url>
 
-# validator registry source will be 'lido' or 'file'
+# Validator registry source will be "lido" or "file" (optional).
 VALIDATOR_REGISTRY_SOURCE=lido
 
-# Critical alerts (optional)
+# Critical alerts (optional).
 # CRITICAL_ALERTS_ALERTMANAGER_URL=http://alertmanager:9093
 # CRITICAL_ALERTS_MIN_VAL_COUNT=1
 
-# Discord web-hook (optional)
+# Discord web-hook (optional).
 # DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...

--- a/.env.example
+++ b/.env.example
@@ -6,20 +6,26 @@ DB_HOST=http://clickhouse
 DB_USER=default
 DB_PASSWORD=
 DB_NAME=default
+
 # Logs
 # log format can be 'simple' or 'json'
 LOG_FORMAT=simple
+
 # select an epoch as close as possible to the last finalized.
-# you can find it here: 
+# you can find it here:
 #  - https://beaconcha.in/epochs
 #  - https://beaconscan.com/epochs
 START_EPOCH=155000
-# you can set URL list (it must be a comma separated string)
-EL_RPC_URLS=https://<network_name>.infura.io/v3/<secret>
+
 # execution layer network id (1 - mainnet, 5 - goerli)
 ETH_NETWORK=1
+
+# you can set URL list (it must be a comma separated string)
+EL_RPC_URLS=https://<network_name>.infura.io/v3/<secret>
+
 # you can set URL list (it must be a comma separated string)
 CL_API_URLS=https://<consensus-layer-api-url>
+
 # validator registry source will be 'lido' or 'file'
 VALIDATOR_REGISTRY_SOURCE=lido
 


### PR DESCRIPTION
Add empty lines between different sections of the sample `.env` file to improve its readability.