### PR TITLE
fix: incorrect calculation in "Earned" column

### DIFF
--- a/docker/grafana/provisioning/dashboards/rewards.json
+++ b/docker/grafana/provisioning/dashboards/rewards.json
@@ -2209,6 +2209,7 @@
           "options": {
             "binary": {
               "left": "Value #reward (sum)",
+              "operator": "-",
               "reducer": "sum",
               "right": "Value #penalty (sum)"
             },
@@ -2230,7 +2231,7 @@
               "Value #missed (sum)": 4,
               "Value #penalty (sum)": 3,
               "Value #reward (sum)": 2,
-              "Value #reward (sum)  Value #penalty (sum)": 6,
+              "Value #reward (sum) - Value #penalty (sum)": 6,
               "Value #reward (sum) / rpm": 1,
               "Value #withdrawn (sum)": 7,
               "nos_name": 0,
@@ -2248,7 +2249,7 @@
               "Value #penalty (sum)": "Penalty",
               "Value #prop (sum)": "Proposal",
               "Value #reward (sum)": "Rewards",
-              "Value #reward (sum)  Value #penalty (sum)": "Earned",
+              "Value #reward (sum) - Value #penalty (sum)": "Earned",
               "Value #reward (sum) / rpm": "Rew. eff.",
               "Value #sync (sum)": "Sync",
               "Value #total (sum)": "Total",


### PR DESCRIPTION
Previously the "Earned" parameter in the "Total summary" table of the "Rewards & Penalties" dashboard was calculated incorrectly. It was calculated as `rewards + penalty`, but actually it should be `rewards - penalty`. Now this bug is fixed and the "Earned" column displays correct values.

![image](https://github.com/lidofinance/ethereum-validators-monitoring/assets/9427757/911924d8-5b8c-411c-834c-bcbcc2039d6d)
