### PR TITLE
feat: support Dencun hard fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,10 @@ Independent of `CL_API_MAX_RETRIES`.
 * **Required:** false
 * **Default:** 155000
 ---
+`DENCUN_FORK_EPOCH` - Ethereum consensus layer epoch when the Dencun hard fork has been released. This value must be set
+only for networks other than Mainnet, Goerli and Holesky.
+* **Required:** false
+---
 `VALIDATOR_REGISTRY_SOURCE` - Validators registry source.
 * **Required:** false
 * **Values:** lido (Lido NodeOperatorsRegistry module keys) / keysapi (Lido keys from multiple modules) / file

--- a/README.md
+++ b/README.md
@@ -240,7 +240,9 @@ Independent of `CL_API_MAX_RETRIES`.
 * **Default:** 155000
 ---
 `DENCUN_FORK_EPOCH` - Ethereum consensus layer epoch when the Dencun hard fork has been released. This value must be set
-only for networks other than Mainnet, Goerli and Holesky.
+only for custom networks that support the Dencun hard fork. If the value of this variable is not specified for a custom
+network, it is supposed that this network doesn't support Dencun. For officially supported networks (Mainnet, Goerli and
+Holesky) this value should be omitted.
 * **Required:** false
 ---
 `VALIDATOR_REGISTRY_SOURCE` - Validators registry source.

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -30,6 +30,7 @@ export class AppService implements OnModuleInit, OnApplicationBootstrap {
     this.logger.log(`DRY RUN ${this.configService.get('DRY_RUN') ? 'enabled' : 'disabled'}`);
     this.logger.log(`Slot time: ${this.configService.get('CHAIN_SLOT_TIME_SECONDS')} seconds`);
     this.logger.log(`Epoch size: ${this.configService.get('FETCH_INTERVAL_SLOTS')} slots`);
+    this.logger.log(`Dencun fork epoch: ${this.configService.get('DENCUN_FORK_EPOCH')}`);
   }
 
   public async onApplicationBootstrap(): Promise<void> {

--- a/src/common/config/env.validation.ts
+++ b/src/common/config/env.validation.ts
@@ -173,6 +173,7 @@ export class EnvironmentVariables {
   @IsValidDencunEpoch()
   @Expose()
   @Transform(transformDencunEpoch)
+  @ValidateIf((vars) => vars.NODE_ENV !== Environment.test)
   public DENCUN_FORK_EPOCH: Epoch;
 
   @IsNumber()

--- a/src/common/config/interfaces/environment.interface.ts
+++ b/src/common/config/interfaces/environment.interface.ts
@@ -18,12 +18,3 @@ export enum LogFormat {
   json = 'json',
   simple = 'simple',
 }
-
-export enum DencunForkEpoch {
-  /**
-   * @todo This should be corrected once the particular epoch of the Dencun hard fork on Mainnet is known.
-   */
-  Mainnet = 300000,
-  Goerli = 231680,
-  Holesky = 29696,
-}

--- a/src/common/config/interfaces/environment.interface.ts
+++ b/src/common/config/interfaces/environment.interface.ts
@@ -18,3 +18,12 @@ export enum LogFormat {
   json = 'json',
   simple = 'simple',
 }
+
+export enum DencunForkEpoch {
+  /**
+   * @todo This should be corrected once the particular epoch of the Dencun hard fork on Mainnet is known.
+   */
+  Mainnet = 300000,
+  Goerli = 231680,
+  Holesky = 29696,
+}

--- a/src/duty/attestation/attestation.constants.ts
+++ b/src/duty/attestation/attestation.constants.ts
@@ -4,27 +4,27 @@ export const TIMELY_TARGET_WEIGHT = 26; // Wt
 export const TIMELY_HEAD_WEIGHT = 14; // Wh
 const WEIGHT_DENOMINATOR = 64; // W sigma
 
-const timelySource = (att_inc_delay: number, att_valid_source: boolean): boolean => {
-  return att_valid_source && att_inc_delay <= 5;
+const timelySource = (attIncDelay: number, attValidSource: boolean): boolean => {
+  return attValidSource && attIncDelay <= 5;
 };
-const timelyTarget = (att_inc_delay: number, att_valid_source: boolean, att_valid_target: boolean, before_dencun): boolean => {
-  return att_valid_source && att_valid_target && (!before_dencun || att_inc_delay <= 32);
+const timelyTarget = (attIncDelay: number, attValidSource: boolean, attValidTarget: boolean, beforeDencun): boolean => {
+  return attValidSource && attValidTarget && (!beforeDencun || attIncDelay <= 32);
 };
-const timelyHead = (att_inc_delay: number, att_valid_source: boolean, att_valid_target: boolean, att_valid_head: boolean): boolean => {
-  return att_valid_source && att_valid_target && att_valid_head && att_inc_delay == 1;
+const timelyHead = (attIncDelay: number, attValidSource: boolean, attValidTarget: boolean, attValidHead: boolean): boolean => {
+  return attValidSource && attValidTarget && attValidHead && attIncDelay == 1;
 };
 
 export const getFlags = (
-  att_inc_delay: number,
-  att_valid_source: boolean,
-  att_valid_target: boolean,
-  att_valid_head: boolean,
-  before_dencun: boolean,
+  attIncDelay: number,
+  attValidSource: boolean,
+  attValidTarget: boolean,
+  attValidHead: boolean,
+  beforeDencun: boolean,
 ) => {
   return {
-    source: timelySource(att_inc_delay, att_valid_source),
-    target: timelyTarget(att_inc_delay, att_valid_source, att_valid_target, before_dencun),
-    head: timelyHead(att_inc_delay, att_valid_source, att_valid_target, att_valid_head),
+    source: timelySource(attIncDelay, attValidSource),
+    target: timelyTarget(attIncDelay, attValidSource, attValidTarget, beforeDencun),
+    head: timelyHead(attIncDelay, attValidSource, attValidTarget, attValidHead),
   };
 };
 

--- a/src/duty/attestation/attestation.constants.ts
+++ b/src/duty/attestation/attestation.constants.ts
@@ -4,24 +4,26 @@ export const TIMELY_TARGET_WEIGHT = 26; // Wt
 export const TIMELY_HEAD_WEIGHT = 14; // Wh
 const WEIGHT_DENOMINATOR = 64; // W sigma
 
-export const timelySource = (att_inc_delay: number, att_valid_source: boolean): boolean => {
+const timelySource = (att_inc_delay: number, att_valid_source: boolean): boolean => {
   return att_valid_source && att_inc_delay <= 5;
 };
-export const timelyTarget = (att_inc_delay: number, att_valid_source: boolean, att_valid_target: boolean): boolean => {
-  return att_valid_source && att_valid_target && att_inc_delay <= 32;
+const timelyTarget = (att_inc_delay: number, att_valid_source: boolean, att_valid_target: boolean, before_dencun): boolean => {
+  return att_valid_source && att_valid_target && (!before_dencun || att_inc_delay <= 32);
 };
-export const timelyHead = (
+const timelyHead = (att_inc_delay: number, att_valid_source: boolean, att_valid_target: boolean, att_valid_head: boolean): boolean => {
+  return att_valid_source && att_valid_target && att_valid_head && att_inc_delay == 1;
+};
+
+export const getFlags = (
   att_inc_delay: number,
   att_valid_source: boolean,
   att_valid_target: boolean,
   att_valid_head: boolean,
-): boolean => {
-  return att_valid_source && att_valid_target && att_valid_head && att_inc_delay == 1;
-};
-export const getFlags = (att_inc_delay: number, att_valid_source: boolean, att_valid_target: boolean, att_valid_head: boolean) => {
+  before_dencun: boolean,
+) => {
   return {
     source: timelySource(att_inc_delay, att_valid_source),
-    target: timelyTarget(att_inc_delay, att_valid_source, att_valid_target),
+    target: timelyTarget(att_inc_delay, att_valid_source, att_valid_target, before_dencun),
     head: timelyHead(att_inc_delay, att_valid_source, att_valid_target, att_valid_head),
   };
 };

--- a/src/duty/attestation/attestation.constants.ts
+++ b/src/duty/attestation/attestation.constants.ts
@@ -7,11 +7,17 @@ const WEIGHT_DENOMINATOR = 64; // W sigma
 const timelySource = (attIncDelay: number, attValidSource: boolean): boolean => {
   return attValidSource && attIncDelay <= 5;
 };
-const timelyTarget = (attIncDelay: number, attValidSource: boolean, attValidTarget: boolean, beforeDencun): boolean => {
-  return attValidSource && attValidTarget && (!beforeDencun || attIncDelay <= 32);
+
+const timelyTarget = (attIncDelay: number, attValidSource: boolean, attValidTarget: boolean): boolean => {
+  return attValidSource && attValidTarget && attIncDelay <= 32;
 };
+
+const timelyTargetDencun = (attValidSource: boolean, attValidTarget: boolean): boolean => {
+  return attValidSource && attValidTarget;
+};
+
 const timelyHead = (attIncDelay: number, attValidSource: boolean, attValidTarget: boolean, attValidHead: boolean): boolean => {
-  return attValidSource && attValidTarget && attValidHead && attIncDelay == 1;
+  return attValidSource && attValidTarget && attValidHead && attIncDelay === 1;
 };
 
 export const getFlags = (
@@ -19,11 +25,11 @@ export const getFlags = (
   attValidSource: boolean,
   attValidTarget: boolean,
   attValidHead: boolean,
-  beforeDencun: boolean,
+  isDencunFork: boolean,
 ) => {
   return {
     source: timelySource(attIncDelay, attValidSource),
-    target: timelyTarget(attIncDelay, attValidSource, attValidTarget, beforeDencun),
+    target: isDencunFork ? timelyTargetDencun(attValidSource, attValidTarget) : timelyTarget(attIncDelay, attValidSource, attValidTarget),
     head: timelyHead(attIncDelay, attValidSource, attValidTarget, attValidHead),
   };
 };

--- a/src/duty/attestation/attestation.service.ts
+++ b/src/duty/attestation/attestation.service.ts
@@ -88,8 +88,8 @@ export class AttestationService {
     const attValidTarget = attestation.target_root == canonTarget;
     const attValidSource = attestation.source_root == canonSource;
     const attIncDelay = Number(attestation.included_in_block - attestation.slot);
-    const beforeDencun = epoch < this.dencunEpoch;
-    const flags = getFlags(attIncDelay, attValidSource, attValidTarget, attValidHead, beforeDencun);
+    const isDencunFork = epoch < this.dencunEpoch;
+    const flags = getFlags(attIncDelay, attValidSource, attValidTarget, attValidHead, isDencunFork);
     for (const [valCommIndex, validatorIndex] of committee.entries()) {
       const attHappened = attestation.bits.get(valCommIndex);
       if (!attHappened) {

--- a/src/duty/attestation/attestation.service.ts
+++ b/src/duty/attestation/attestation.service.ts
@@ -88,7 +88,7 @@ export class AttestationService {
     const attValidTarget = attestation.target_root == canonTarget;
     const attValidSource = attestation.source_root == canonSource;
     const attIncDelay = Number(attestation.included_in_block - attestation.slot);
-    const isDencunFork = epoch < this.dencunEpoch;
+    const isDencunFork = epoch >= this.dencunEpoch;
     const flags = getFlags(attIncDelay, attValidSource, attValidTarget, attValidHead, isDencunFork);
     for (const [valCommIndex, validatorIndex] of committee.entries()) {
       const attHappened = attestation.bits.get(valCommIndex);


### PR DESCRIPTION
Add support for the new attestation logic introduced in the EIP-7045
which is a part of the Dencun hard fork spec.

The only part of the Dencun hard fork that affects E-V-M is the EIP-7045. Here is an exact change that should be supported:
https://github.com/ethereum/consensus-specs/blob/bf09b9a7c4a7b311e86823235815daf31b117574/specs/deneb/beacon-chain.md#modified-get_attestation_participation_flag_indices

Other improvements listed in the Dencun spec don't affect E-V-M.

Now the `attestation_inclusion_delay` is ignored for slots after the Dencun hard fork epoch. For slots before the Dencun hard fork epoch the app works as previously (i. e. checks that the `attestation_inclusion_delay` is not greater than 32).

The Dencun hard fork epoch is predefined for the officially supported networks (Mainnet, Goerli, and Holesky). For other networks, an exact Dencun hard fork epoch can be configured via the new `DENCUN_FORK_EPOCH` environmental variable.

**ToDo.** The correct Dencun epoch for the Mainnet should be set for the `DencunForkEpoch` enum once the exact Dencun epoch for the Mainnet becomes known. We should not merge this PR until this value is corrected.

The appropriate validation for the `DENCUN_FORK_EPOCH` environmental variable has been implemented. It is possible not to set a value for the `DENCUN_FORK_EPOCH` variable if the `ETH_NETWORK` is Mainnet, Goerli, or Holesky. Even if the `ETH_NETWORK` is one of these 3 networks, it is also possible to set the valid Dencun hard fork epoch as the value of the `DENCUN_FORK_EPOCH` variable.
If the `ETH_NETWORK` variable has a value other than 1, 5, or 17000, the value of the `DENCUN_FORK_EPOCH` must be set. If not, the validation error will be returned.

**NOTE.** We need to apply the `@Expose()` decorator to the `DENCUN_FORK_EPOCH` field of the `EnvironmentVariables` class to force calling the handler specified in the `@Transform` decorator when the `DENCUN_FORK_EPOCH` is not presented in the `.env` file.
https://github.com/typestack/class-transformer?tab=readme-ov-file#enforcing-type-safe-instance
The `transformDencunEpoch()` function is responsible for setting the default values for the `DENCUN_FORK_EPOCH` variable and must be called regardless of the `DENCUN_FORK_EPOCH` variable is presented in the `.env` file or not.

Once the `DENCUN_FORK_EPOCH` variable is set in the config, the application assumes that this value is correct and uses this value as the primary source of truth.