### PR TITLE
chore!: remove Kintsugi network

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ ALTER TABLE validators_summary MODIFY TTL toDateTime(1606824023 + (epoch * 32 * 
 ---
 `ETH_NETWORK` - Ethereum network ID for connection execution layer RPC.
 * **Required:** true
-* **Values:** 1 (mainnet) / 5 (goerli) / 17000 (holesky) / 1337702 (kintsugi)
+* **Values:** 1 (Mainnet) / 5 (Goerli) / 17000 (Holesky)
 ---
 `EL_RPC_URLS` - Ethereum execution layer comma-separated RPC URLs.
 * **Required:** true

--- a/src/common/config/env.validation.ts
+++ b/src/common/config/env.validation.ts
@@ -23,7 +23,6 @@ export enum Network {
   Mainnet = 1,
   Goerli = 5,
   Holesky = 17000,
-  Kintsugi = 1337702,
 }
 
 export enum ValidatorRegistrySource {


### PR DESCRIPTION
Remove the Kintsugi network from the list of officially supported chains.

As this network has been officially deprecated and Lido protocol isn't deployed there, it has been decided to remove this network from the list of officially supported chains.