### PR TITLE
fix: retry on non-finalized epoch

### DIFF
--- a/src/common/consensus-provider/consensus-provider.service.ts
+++ b/src/common/consensus-provider/consensus-provider.service.ts
@@ -126,7 +126,7 @@ export class ConsensusProviderService {
           if (Number(r.data.header.message.slot) > this.latestSlot.slot) {
             this.latestSlot = { slot: Number(r.data.header.message.slot), fetchTime: Number(Date.now()) };
           }
-          if (processingState.epoch <= Math.trunc(this.latestSlot.slot / this.config.get('FETCH_INTERVAL_SLOTS'))) {
+          if (processingState.epoch < Math.trunc(this.latestSlot.slot / this.config.get('FETCH_INTERVAL_SLOTS'))) {
             // if our last processed epoch is less than last, we shouldn't use fallback
             return false;
           } else if (Number(Date.now()) - this.latestSlot.fetchTime > 420 * 1000) {


### PR DESCRIPTION
Use fallback if the processing state epoch is greater than or equal to the latest epoch returned by the CL node.