### PR TITLE
fix: set correct Dencun Mainnet epoch

### DIFF
--- a/src/common/config/env.validation.ts
+++ b/src/common/config/env.validation.ts
@@ -39,10 +39,7 @@ export enum WorkingMode {
 }
 
 const dencunForkEpoch = {
-  /**
-   * @todo This should be corrected once the particular epoch of the Dencun hard fork on Mainnet is known.
-   */
-  '1': 300000,
+  '1': 269568,
   '5': 231680,
   '17000': 29696,
 };


### PR DESCRIPTION
Set the correct epoch for Dencun hardfork on Mainnet
https://blog.ethereum.org/2024/02/27/dencun-mainnet-announcement