### PR TITLE
chore: log latest block number from the node

### DIFF
--- a/src/inspector/inspector.service.ts
+++ b/src/inspector/inspector.service.ts
@@ -80,6 +80,8 @@ export class InspectorService implements OnModuleInit {
   protected async getEpochDataToProcess(): Promise<EpochProcessingState & { slot: Slot }> {
     const chosen = await this.chooseEpochToProcess();
     const latestBeaconBlock = Number((<BlockHeaderResponse>await this.clClient.getLatestBlockHeader(chosen)).header.message.slot);
+    this.logger.debug(`getEpochDataToProcess: latest block [${latestBeaconBlock}], chosen epoch [${chosen.epoch}], chosen slot [${chosen.slot}]`);
+
     let latestEpoch = Math.trunc(latestBeaconBlock / this.config.get('FETCH_INTERVAL_SLOTS'));
     if (latestEpoch * this.config.get('FETCH_INTERVAL_SLOTS') == latestBeaconBlock) {
       // if it's the first slot of epoch, it makes checkpoint for previous epoch


### PR DESCRIPTION
Log latest block number received from the node and chosen epoch and slot in the debug logging mode.