### PR TITLE
fix: add more memory to app container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 3g
+          memory: 5g
     ulimits:
       nofile:
         soft: 262144


### PR DESCRIPTION
When the app is launched in docker containers, it is periodically killed by OOM because 3 GB of memory allocated to the app container is not enough. Now the amount of memory is increased to 5 GB.