### PR TITLE
feat: new attestations calculation algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,12 +241,6 @@ Independent of `CL_API_MAX_RETRIES`.
 * **Required:** false
 * **Default:** 155000
 ---
-`DENCUN_FORK_EPOCH` - Ethereum consensus layer epoch when the Dencun hard fork has been released. This value must be set
-only for custom networks that support the Dencun hard fork. If the value of this variable is not specified for a custom
-network, it is supposed that this network doesn't support Dencun. For officially supported networks (Mainnet, Goerli and
-Holesky) this value should be omitted.
-* **Required:** false
----
 `VALIDATOR_REGISTRY_SOURCE` - Validators registry source.
 * **Required:** false
 * **Values:** lido (Lido NodeOperatorsRegistry module keys) / keysapi (Lido keys from multiple modules) / file

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@lido-nestjs/execution": "^1.11.1",
     "@lido-nestjs/logger": "^1.3.2",
     "@lido-nestjs/registry": "^7.4.0",
-    "@lodestar/types": "^1.15.1",
+    "@lodestar/types": "^1.24.0",
     "@mikro-orm/core": "^5.3.1",
     "@mikro-orm/knex": "^5.3.1",
     "@mikro-orm/nestjs": "^5.1.0",

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -30,7 +30,6 @@ export class AppService implements OnModuleInit, OnApplicationBootstrap {
     this.logger.log(`DRY RUN ${this.configService.get('DRY_RUN') ? 'enabled' : 'disabled'}`);
     this.logger.log(`Slot time: ${this.configService.get('CHAIN_SLOT_TIME_SECONDS')} seconds`);
     this.logger.log(`Epoch size: ${this.configService.get('FETCH_INTERVAL_SLOTS')} slots`);
-    this.logger.log(`Dencun fork epoch: ${this.configService.get('DENCUN_FORK_EPOCH')}`);
   }
 
   public async onApplicationBootstrap(): Promise<void> {

--- a/src/common/config/env.validation.ts
+++ b/src/common/config/env.validation.ts
@@ -1,4 +1,4 @@
-import { Expose, Transform, plainToInstance } from 'class-transformer';
+import { Transform, plainToInstance } from 'class-transformer';
 import {
   ArrayMinSize,
   IsArray,
@@ -9,7 +9,6 @@ import {
   IsNumber,
   IsObject,
   IsPort,
-  IsPositive,
   IsString,
   Max,
   Min,
@@ -17,8 +16,6 @@ import {
   ValidateIf,
   validateSync,
 } from 'class-validator';
-
-import { Epoch } from 'common/consensus-provider/types';
 
 import { Environment, LogFormat, LogLevel } from './interfaces';
 
@@ -38,12 +35,6 @@ export enum WorkingMode {
   Finalized = 'finalized',
   Head = 'head',
 }
-
-const dencunForkEpoch = {
-  '1': 269568,
-  '5': 231680,
-  '17000': 29696,
-};
 
 const toBoolean = (value: any): boolean => {
   if (typeof value === 'boolean') {
@@ -170,15 +161,6 @@ export class EnvironmentVariables {
   @Transform(({ value }) => parseInt(value, 10), { toClassOnly: true })
   @ValidateIf((vars) => vars.ETH_NETWORK === Network.Mainnet)
   public START_EPOCH = 155000;
-
-  @IsInt()
-  @IsPositive()
-  @Expose()
-  @Transform(
-    ({ value, obj }) =>
-      dencunForkEpoch[obj.ETH_NETWORK] || (value != null && value.trim() !== '' ? parseInt(value, 10) : Number.MAX_SAFE_INTEGER),
-  )
-  public DENCUN_FORK_EPOCH: Epoch;
 
   @IsNumber()
   @Min(32)

--- a/src/common/consensus-provider/consensus-provider.service.ts
+++ b/src/common/consensus-provider/consensus-provider.service.ts
@@ -15,7 +15,15 @@ import { EpochProcessingState } from 'storage/clickhouse';
 
 import { BlockCache, BlockCacheService } from './block-cache';
 import { MaxDeepError, ResponseError, errCommon, errRequest } from './errors';
-import { BlockHeaderResponse, BlockInfoResponse, GenesisResponse, ProposerDutyInfo, SyncCommitteeInfo, VersionResponse, SpecResponse } from './intefaces';
+import {
+  BlockHeaderResponse,
+  BlockInfoResponse,
+  GenesisResponse,
+  ProposerDutyInfo,
+  SpecResponse,
+  SyncCommitteeInfo,
+  VersionResponse,
+} from './intefaces';
 import { BlockId, Epoch, Slot, StateId } from './types';
 
 let ssz: typeof import('@lodestar/types').ssz;

--- a/src/common/consensus-provider/consensus-provider.service.ts
+++ b/src/common/consensus-provider/consensus-provider.service.ts
@@ -38,8 +38,8 @@ interface RequestRetryOptions {
 }
 
 export interface ForkEpochs {
-  dencun: number;
-  pectra: number;
+  deneb: number;
+  electra: number;
 }
 
 @Injectable()
@@ -90,12 +90,12 @@ export class ConsensusProviderService {
 
     const spec = await this.retryRequest<SpecResponse>(async (apiURL: string) => this.apiGet(apiURL, this.endpoints.spec));
     this.forkEpochs = {
-      dencun: spec.DENEB_FORK_EPOCH != null ? parseInt(spec.DENEB_FORK_EPOCH, 10) : Number.MAX_SAFE_INTEGER,
-      pectra: spec.ELECTRA_FORK_EPOCH != null ? parseInt(spec.ELECTRA_FORK_EPOCH, 10) : Number.MAX_SAFE_INTEGER,
+      deneb: spec.DENEB_FORK_EPOCH != null ? parseInt(spec.DENEB_FORK_EPOCH, 10) : Number.MAX_SAFE_INTEGER,
+      electra: spec.ELECTRA_FORK_EPOCH != null ? parseInt(spec.ELECTRA_FORK_EPOCH, 10) : Number.MAX_SAFE_INTEGER,
     };
 
-    this.logger.log(`Dencun fork epoch: ${this.forkEpochs.dencun}`);
-    this.logger.log(`Pectra fork epoch: ${this.forkEpochs.pectra}`);
+    this.logger.log(`Deneb fork epoch: ${this.forkEpochs.deneb}`);
+    this.logger.log(`Electra fork epoch: ${this.forkEpochs.electra}`);
 
     return this.forkEpochs;
   }

--- a/src/common/consensus-provider/intefaces/response.interface.ts
+++ b/src/common/consensus-provider/intefaces/response.interface.ts
@@ -80,6 +80,7 @@ export interface ProposerDutyInfo {
 
 export interface BeaconBlockAttestation {
   aggregation_bits: string;
+  committee_bits?: string;
   data: {
     slot: string;
     index: string;
@@ -93,33 +94,6 @@ export interface BeaconBlockAttestation {
       root: RootHex;
     };
   };
-  committee_bits: string;
-}
-
-export interface StateValidatorResponse {
-  index: string;
-  balance: string;
-  status: (typeof ValStatus)[keyof typeof ValStatus];
-  validator: {
-    pubkey: string;
-    withdrawal_credentials: string;
-    effective_balance: string;
-    slashed: boolean;
-    activation_eligibility_epoch: string;
-    activation_epoch: string;
-    exit_epoch: string;
-    withdrawable_epoch: string;
-  };
-}
-
-export interface SyncCommitteeDutyInfo {
-  pubkey: string;
-  validator_index: ValidatorIndex;
-  validator_sync_committee_indices: string[];
-  results: {
-    block: string;
-    sync: boolean;
-  }[];
 }
 
 export interface SyncCommitteeInfo {
@@ -140,4 +114,9 @@ export interface SyncCommitteeValidator {
 
 export interface VersionResponse {
   version: string;
+}
+
+export interface SpecResponse {
+  DENEB_FORK_EPOCH?: string;
+  ELECTRA_FORK_EPOCH?: string;
 }

--- a/src/common/consensus-provider/intefaces/response.interface.ts
+++ b/src/common/consensus-provider/intefaces/response.interface.ts
@@ -12,25 +12,6 @@ export enum ValStatus {
   WithdrawalDone = 'withdrawal_done',
 }
 
-export interface AttesterDutyInfo {
-  pubkey: string;
-  validator_index: string;
-  committee_index: string;
-  committee_length: string;
-  committees_at_slot: string;
-  validator_committee_index: string;
-  slot: string;
-}
-
-export interface CheckedAttesterDutyInfo extends AttesterDutyInfo {
-  attested: boolean;
-  valid_head: boolean;
-  valid_target: boolean;
-  valid_source: boolean;
-  inclusion_delay: number;
-  in_block: string | undefined;
-}
-
 export interface BlockHeaderResponse {
   root: RootHex;
   canonical: boolean;
@@ -112,6 +93,7 @@ export interface BeaconBlockAttestation {
       root: RootHex;
     };
   };
+  committee_bits: string;
 }
 
 export interface StateValidatorResponse {

--- a/src/common/functions/makeDefaultMap.ts
+++ b/src/common/functions/makeDefaultMap.ts
@@ -1,0 +1,15 @@
+export function makeDefaultMap<TKey, TValue>(factory: (key: TKey) => TValue) {
+  const cache = new Map<TKey, TValue>();
+
+  return {
+    getOrCreate: (key: TKey) => {
+      let value = cache.get(key);
+      if (value === undefined) {
+        value = factory(key);
+        cache.set(key, value);
+      }
+
+      return value;
+    },
+  };
+}

--- a/src/duty/attestation/attestation.constants.ts
+++ b/src/duty/attestation/attestation.constants.ts
@@ -12,7 +12,7 @@ const timelyTarget = (attIncDelay: number, attValidSource: boolean, attValidTarg
   return attValidSource && attValidTarget && attIncDelay <= 32;
 };
 
-const timelyTargetDencun = (attValidSource: boolean, attValidTarget: boolean): boolean => {
+const timelyTargetDeneb = (attValidSource: boolean, attValidTarget: boolean): boolean => {
   return attValidSource && attValidTarget;
 };
 
@@ -25,11 +25,11 @@ export const getAttestationFlags = (
   attValidSource: boolean,
   attValidTarget: boolean,
   attValidHead: boolean,
-  isDencunFork: boolean,
+  isDenebFork: boolean,
 ) => {
   return {
     source: timelySource(attIncDelay, attValidSource),
-    target: isDencunFork ? timelyTargetDencun(attValidSource, attValidTarget) : timelyTarget(attIncDelay, attValidSource, attValidTarget),
+    target: isDenebFork ? timelyTargetDeneb(attValidSource, attValidTarget) : timelyTarget(attIncDelay, attValidSource, attValidTarget),
     head: timelyHead(attIncDelay, attValidSource, attValidTarget, attValidHead),
   };
 };

--- a/src/duty/attestation/attestation.constants.ts
+++ b/src/duty/attestation/attestation.constants.ts
@@ -20,7 +20,7 @@ const timelyHead = (attIncDelay: number, attValidSource: boolean, attValidTarget
   return attValidSource && attValidTarget && attValidHead && attIncDelay === 1;
 };
 
-export const getFlags = (
+export const getAttestationFlags = (
   attIncDelay: number,
   attValidSource: boolean,
   attValidTarget: boolean,

--- a/src/duty/attestation/attestation.service.ts
+++ b/src/duty/attestation/attestation.service.ts
@@ -98,7 +98,7 @@ export class AttestationService {
     ]);
 
     const forkEpochs = await this.clClient.getForkEpochs();
-    const attestationEpoch = attestation.includedInBlock / this.slotsInEpoch;
+    const attestationEpoch = Math.floor(attestation.includedInBlock / this.slotsInEpoch);
     const isDenebFork = attestationEpoch >= forkEpochs.deneb;
     const isElectraFork = attestationEpoch >= forkEpochs.electra;
 

--- a/src/duty/attestation/attestation.service.ts
+++ b/src/duty/attestation/attestation.service.ts
@@ -174,7 +174,7 @@ export class AttestationService {
         }
 
         const includedInBlock = Number(block.message.slot);
-        const isElectraFork = includedInBlock / this.slotsInEpoch >= forkEpochs.electra;
+        const isElectraFork = Math.floor(includedInBlock / this.slotsInEpoch) >= forkEpochs.electra;
         let committeeIndexes: number[] | null;
         if (isElectraFork) {
           committeeIndexes = committeeIndexesMap.get(att.committee_bits);

--- a/src/duty/attestation/attestation.service.ts
+++ b/src/duty/attestation/attestation.service.ts
@@ -99,16 +99,17 @@ export class AttestationService {
 
     const forkEpochs = await this.clClient.getForkEpochs();
     const attestationEpoch = attestation.includedInBlock / this.slotsInEpoch;
-    const isDencunFork = attestationEpoch >= forkEpochs.dencun;
-    const isPectraFork = attestationEpoch >= forkEpochs.pectra;
+    const isDenebFork = attestationEpoch >= forkEpochs.deneb;
+    const isElectraFork = attestationEpoch >= forkEpochs.electra;
+
 
     const attValidHead = attestation.head === canonHead;
     const attValidTarget = attestation.targetRoot === canonTarget;
     const attValidSource = attestation.sourceRoot === canonSource;
     const attIncDelay = Number(attestation.includedInBlock - attestation.slot);
-    const flags = getAttestationFlags(attIncDelay, attValidSource, attValidTarget, attValidHead, isDencunFork);
+    const flags = getAttestationFlags(attIncDelay, attValidSource, attValidTarget, attValidHead, isDenebFork);
 
-    if (isPectraFork) {
+    if (isElectraFork) {
       let committeeOffset = 0;
       for (const committeeIndex of attestation.committeeIndexes) {
         // Each attestation corresponds to committee. Committee may have several aggregate attestations
@@ -191,9 +192,9 @@ export class AttestationService {
         }
 
         const includedInBlock = Number(block.message.slot);
-        const isPectraFork = includedInBlock / this.slotsInEpoch >= forkEpochs.pectra;
+        const isElectraFork = includedInBlock / this.slotsInEpoch >= forkEpochs.electra;
         let committeeIndexes: number[] | null;
-        if (isPectraFork) {
+        if (isElectraFork) {
           committeeIndexes = committeeIndexesMap.get(att.committee_bits);
           if (committeeIndexes == null) {
             const bytesArray = fromHexString(att.committee_bits);
@@ -207,7 +208,7 @@ export class AttestationService {
         attestations.push({
           includedInBlock: includedInBlock,
           aggregationBits,
-          committeeIndexes: isPectraFork ? committeeIndexes : null,
+          committeeIndexes: isElectraFork ? committeeIndexes : null,
           head: att.data.beacon_block_root,
           targetRoot: att.data.target.root,
           targetEpoch: Number(att.data.target.epoch),

--- a/src/duty/attestation/attestation.service.ts
+++ b/src/duty/attestation/attestation.service.ts
@@ -43,7 +43,6 @@ interface AttestationFlags {
   head: boolean;
 }
 
-
 @Injectable()
 export class AttestationService {
   private processedEpoch: number;
@@ -278,7 +277,7 @@ export class AttestationService {
     attIncDelay: number,
     validatorIndex: number,
     attestationFlags: AttestationFlags,
-    attestationValidators: AttestationValidators
+    attestationValidators: AttestationValidators,
   ) {
     const processed = this.summary.epoch(attestation.targetEpoch).get(validatorIndex);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -353,6 +353,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@chainsafe/as-sha256@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-0.5.0.tgz#2523fbef2b80b5000f9aa71f4a76e5c2c5c076bb"
+  integrity sha512-dTIY6oUZNdC5yDTVP5Qc9hAlKAsn0QTQ2DnQvvsbTnKSTbYs3p5RPN0aIUqN0liXei/9h24c7V0dkV44cnWIQA==
+
 "@chainsafe/as-sha256@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz#3639df0e1435cab03f4d9870cc3ac079e57a6fc9"
@@ -363,20 +368,45 @@
   resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-0.4.1.tgz#cfc0737e25f8c206767bdb6703e7943e5d44513e"
   integrity sha512-IqeeGwQihK6Y2EYLFofqs2eY2ep1I2MvQXHzOAI+5iQN51OZlUkrLgyAugu2x86xZewDk5xas7lNczkzFzF62w==
 
+"@chainsafe/hashtree-darwin-arm64@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/hashtree-darwin-arm64/-/hashtree-darwin-arm64-1.0.1.tgz#e2c60090c56a1c8dc8bdff329856184ad32e4cd5"
+  integrity sha512-+KmEgQMpO7FDL3klAcpXbQ4DPZvfCe0qSaBBrtT4vLF8V1JGm3sp+j7oibtxtOsLKz7nJMiK1pZExi7vjXu8og==
+
+"@chainsafe/hashtree-linux-arm64-gnu@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/hashtree-linux-arm64-gnu/-/hashtree-linux-arm64-gnu-1.0.1.tgz#49d2604a6c9106219448af3eaf76f4da6e44daca"
+  integrity sha512-p1hnhGq2aFY+Zhdn1Q6L/6yLYNKjqXfn/Pc8jiM0e3+Lf/hB+yCdqYVu1pto26BrZjugCFZfupHaL4DjUTDttw==
+
+"@chainsafe/hashtree-linux-x64-gnu@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/hashtree-linux-x64-gnu/-/hashtree-linux-x64-gnu-1.0.1.tgz#31c5a2bb196b78f04f2bf4bfb5c1bf1f3331f071"
+  integrity sha512-uCIGuUWuWV0LiB4KLMy6JFa7Jp6NmPl3hKF5BYWu8TzUBe7vSXMZfqTzGxXPggFYN2/0KymfRdG9iDCOJfGRqg==
+
+"@chainsafe/hashtree@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/hashtree/-/hashtree-1.0.1.tgz#587666a261e1da6a37904095ce875fddc53c7c89"
+  integrity sha512-bleu9FjqBeR/l6W1u2Lz+HsS0b0LLJX2eUt3hOPBN7VqOhidx8wzkVh2S7YurS+iTQtfdK4K5QU9tcTGNrGwDg==
+  optionalDependencies:
+    "@chainsafe/hashtree-darwin-arm64" "1.0.1"
+    "@chainsafe/hashtree-linux-arm64-gnu" "1.0.1"
+    "@chainsafe/hashtree-linux-x64-gnu" "1.0.1"
+
+"@chainsafe/persistent-merkle-tree@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.8.0.tgz#18e2f0a5de3a0b59c6e5be8797a78e0d209dd7dc"
+  integrity sha512-hh6C1JO6SKlr0QGNTNtTLqgGVMA/Bc20wD6CeMHp+wqbFKCULRJuBUxhF4WDx/7mX8QlqF3nFriF/Eo8oYJ4/A==
+  dependencies:
+    "@chainsafe/as-sha256" "0.5.0"
+    "@chainsafe/hashtree" "1.0.1"
+    "@noble/hashes" "^1.3.0"
+
 "@chainsafe/persistent-merkle-tree@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.4.2.tgz#4c9ee80cc57cd3be7208d98c40014ad38f36f7ff"
   integrity sha512-lLO3ihKPngXLTus/L7WHKaw9PnNJWizlOF1H9NNzHP6Xvh82vzg9F2bzkXhYIFshMZ2gTCEz8tq6STe7r5NDfQ==
   dependencies:
     "@chainsafe/as-sha256" "^0.3.1"
-
-"@chainsafe/persistent-merkle-tree@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.6.1.tgz#37bde25cf6cbe1660ad84311aa73157dc86ec7f2"
-  integrity sha512-gcENLemRR13+1MED2NeZBMA7FRS0xQPM7L2vhMqvKkjqtFT4YfjSVADq5U0iLuQLhFUJEMVuA8fbv5v+TN6O9A==
-  dependencies:
-    "@chainsafe/as-sha256" "^0.4.1"
-    "@noble/hashes" "^1.3.0"
 
 "@chainsafe/persistent-merkle-tree@^0.7.1":
   version "0.7.1"
@@ -386,13 +416,13 @@
     "@chainsafe/as-sha256" "^0.4.1"
     "@noble/hashes" "^1.3.0"
 
-"@chainsafe/ssz@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.14.0.tgz#fe9e4fd3cf673013bd57f77c3ab0fdc5ebc5d916"
-  integrity sha512-KTc33pWu7ItXlzMAz5/1osOHsvhx25kpM3j7Ez+PNZLyyhIoNzAhhozvxy+ul0fCDfHbvaCRp3lJQnzsb5Iv0A==
+"@chainsafe/ssz@^0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.18.0.tgz#773d40df9dff3b6a2a4c6685d9797abceb9d36f7"
+  integrity sha512-1ikTjk3JK6+fsGWiT5IvQU0AP6gF3fDzGmPfkKthbcbgTUR8fjB83Ywp9ko/ZoiDGfrSFkATgT4hvRzclu0IAA==
   dependencies:
-    "@chainsafe/as-sha256" "^0.4.1"
-    "@chainsafe/persistent-merkle-tree" "^0.6.1"
+    "@chainsafe/as-sha256" "0.5.0"
+    "@chainsafe/persistent-merkle-tree" "0.8.0"
 
 "@chainsafe/ssz@^0.9.4":
   version "0.9.4"
@@ -1201,18 +1231,19 @@
   resolved "https://registry.yarnpkg.com/@lido-nestjs/utils/-/utils-1.3.0.tgz#8bdc69c3fd18bc57752b1799516096d284f1112b"
   integrity sha512-/5I30Dos9TC18YfZq8O9ele28DpUQQCySB9X9GXPeSmY1AV4w2kIGQrws1wu2gtw7x5mZnW8PtWthJmH1f6vJQ==
 
-"@lodestar/params@^1.15.1":
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/@lodestar/params/-/params-1.15.1.tgz#db8754c402bee12324abc33ea83f3a23f8f7e1d7"
-  integrity sha512-9SD+HWBxwJNZy4t0icuGIZSqPRYJBqk/kHLkCFNCh46wZS4nrGezNM0HUawyaW3fiZyqUW+QJEfok51n1BBkLw==
+"@lodestar/params@^1.25.0":
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/@lodestar/params/-/params-1.25.0.tgz#34d2f60fa3239e97ca44c29157f12584f578ff14"
+  integrity sha512-NOu67lfyEZwYmwn1dhxE3IHyZ00ybTpVVnv0D9FIB5+o7Mzio7Ff37osNucwbxVx9SvCa41PfbGmwcNMVjUxfw==
 
-"@lodestar/types@^1.15.1":
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/@lodestar/types/-/types-1.15.1.tgz#fe67679202c853cda99c99326ee376470fb143e7"
-  integrity sha512-Xbdg4dvXOX0x2VnPu/puUKuCORWprT1Pz8W0DBSROJ2ajYmGmyDbxoxt9ilINeC8vJW+f1cstKTCWVfodsDdcA==
+"@lodestar/types@^1.24.0":
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/@lodestar/types/-/types-1.25.0.tgz#06150c78f60bf17451f689a554c25f12d0fb9a99"
+  integrity sha512-PG1X4uxDHzpZj30XzbnOx5UiVS0JtFk9eHJ9B+eaQOTfH8fClISPCq3vGuk8OkTVjKoOnZhBe+BEIj7NE7rCeQ==
   dependencies:
-    "@chainsafe/ssz" "^0.14.0"
-    "@lodestar/params" "^1.15.1"
+    "@chainsafe/ssz" "^0.18.0"
+    "@lodestar/params" "^1.25.0"
+    ethereum-cryptography "^2.0.0"
 
 "@lukeed/csprng@^1.0.0":
   version "1.1.0"
@@ -1368,6 +1399,18 @@
   dependencies:
     tslib "2.5.3"
 
+"@noble/curves@1.4.2", "@noble/curves@~1.4.0":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.4.2.tgz#40309198c76ed71bc6dbf7ba24e81ceb4d0d1fe9"
+  integrity sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==
+  dependencies:
+    "@noble/hashes" "1.4.0"
+
+"@noble/hashes@1.4.0", "@noble/hashes@~1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
+  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+
 "@noble/hashes@^1.3.0":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
@@ -1418,6 +1461,28 @@
     chalk "^4.1.0"
     consola "^2.15.0"
     node-fetch "^2.6.1"
+
+"@scure/base@~1.1.6":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
+  integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
+
+"@scure/bip32@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.4.0.tgz#4e1f1e196abedcef395b33b9674a042524e20d67"
+  integrity sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==
+  dependencies:
+    "@noble/curves" "~1.4.0"
+    "@noble/hashes" "~1.4.0"
+    "@scure/base" "~1.1.6"
+
+"@scure/bip39@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.3.0.tgz#0f258c16823ddd00739461ac31398b4e7d6a18c3"
+  integrity sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==
+  dependencies:
+    "@noble/hashes" "~1.4.0"
+    "@scure/base" "~1.1.6"
 
 "@sindresorhus/is@4.6.0":
   version "4.6.0"
@@ -3479,6 +3544,16 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+ethereum-cryptography@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz#58f2810f8e020aecb97de8c8c76147600b0b8ccf"
+  integrity sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==
+  dependencies:
+    "@noble/curves" "1.4.2"
+    "@noble/hashes" "1.4.0"
+    "@scure/bip32" "1.4.0"
+    "@scure/bip39" "1.3.0"
 
 ethers@^5.4.2, ethers@^5.5.4:
   version "5.7.2"


### PR DESCRIPTION
Implement a prototype of the new algorithm for attestation calculation to support the new attestation data format introduced in the EIP-7549 that will be added to the next Pectra hardfork.

Some useful links that illustrate new data format and calculation rules
- https://eips.ethereum.org/EIPS/eip-7549
- https://github.com/ethereum/consensus-specs/blob/2c1f677187e6534aec77057a7d1cc746a40d3630/specs/electra/beacon-chain.md#attestation
- https://github.com/ethereum/consensus-specs/blob/2c1f677187e6534aec77057a7d1cc746a40d3630/specs/electra/beacon-chain.md#get_committee_indices
- https://github.com/ethereum/consensus-specs/blob/2c1f677187e6534aec77057a7d1cc746a40d3630/specs/electra/beacon-chain.md#modified-get_attesting_indices

**Open questions:**
What to do if the `committee` in the `processAttestation` method is `null`? In the previous version of this algorithm, it just skipped that attestation and went ahead. But in the new version of the algorithm, if a committee doesn't exist in the `committees` data structure if the algorithm skips this committee, it will mean that all attestations aggregated by this committee will be skipped.