### PR TITLE
fix: sync committee accounting

### DIFF
--- a/src/duty/duty.service.ts
+++ b/src/duty/duty.service.ts
@@ -117,6 +117,7 @@ export class DutyService {
     const perSyncProposerReward = Math.floor((meta.sync.per_block_reward * PROPOSER_WEIGHT) / (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT));
     const maxBatchSize = 1000;
     let index = 0;
+
     for (const v of this.summary.epoch(epoch).values()) {
       const effectiveBalance = v.val_effective_balance;
       const increments = Number(effectiveBalance / BigInt(10 ** 9));
@@ -135,8 +136,11 @@ export class DutyService {
         }
       }
       if (v.is_sync) {
-        for (const block of v.sync_meta.synced_blocks) {
-          meta.sync.blocks_rewards.set(block, meta.sync.blocks_rewards.get(block) + BigInt(perSyncProposerReward));
+        for (const syncMetaItem of v.sync_meta) {
+          for (const block of syncMetaItem.synced_blocks) {
+            const blockRewards = meta.sync.blocks_rewards.get(block);
+            meta.sync.blocks_rewards.set(block, blockRewards + BigInt(perSyncProposerReward));
+          }
         }
       }
       index++;
@@ -144,6 +148,7 @@ export class DutyService {
         await unblock();
       }
     }
+
     this.summary.epoch(epoch).setMeta(meta);
   }
 

--- a/src/duty/summary/summary.service.ts
+++ b/src/duty/summary/summary.service.ts
@@ -100,7 +100,7 @@ export class SummaryService {
         const curr = epochStorageData.summary.get(val.val_id) ?? {};
         epochStorageData.summary.set(val.val_id, merge(curr, val));
       },
-      get: (val_id: ValidatorId): ValidatorDutySummary => {
+      get: (val_id: ValidatorId): ValidatorDutySummary | undefined => {
         return epochStorageData.summary.get(val_id);
       },
       values: () => {

--- a/src/duty/summary/summary.service.ts
+++ b/src/duty/summary/summary.service.ts
@@ -37,8 +37,8 @@ export interface ValidatorDutySummary {
   att_valid_source?: boolean;
   // Metadata. Necessary for calculating rewards and will not be stored in DB
   sync_meta?: {
-    synced_blocks?: number[];
-  };
+    synced_blocks: number[];
+  }[];
   // Rewards
   att_earned_reward?: number;
   att_missed_reward?: number;

--- a/src/duty/sync/sync.rewards.ts
+++ b/src/duty/sync/sync.rewards.ts
@@ -17,17 +17,27 @@ export class SyncRewards {
 
   public async calculate(epoch: Epoch) {
     const epochMeta = this.summary.epoch(epoch).getMeta();
-    let sync_earned_reward = 0;
-    let sync_missed_reward = 0;
-    let sync_penalty = 0;
-    const perfectSync = epochMeta.sync.per_block_reward * epochMeta.sync.blocks_to_sync.length;
     for (const v of this.summary.epoch(epoch).values()) {
-      if (!v.is_sync) continue;
-      sync_earned_reward = epochMeta.sync.per_block_reward * v.sync_meta.synced_blocks.length;
-      sync_penalty = epochMeta.sync.per_block_reward * (epochMeta.sync.blocks_to_sync.length - v.sync_meta.synced_blocks.length);
-      sync_missed_reward = perfectSync - sync_earned_reward;
+      if (!v.is_sync) {
+        continue;
+      }
 
-      this.summary.epoch(epoch).set({ epoch, val_id: v.val_id, sync_earned_reward, sync_penalty, sync_missed_reward });
+      const totalBlocksToSync = epochMeta.sync.blocks_to_sync.length * v.sync_meta.length;
+      const perfectSync = epochMeta.sync.per_block_reward * totalBlocksToSync;
+
+      let totalSyncedBlocksCount = 0;
+      for (const syncMetaItem of v.sync_meta) {
+        totalSyncedBlocksCount += syncMetaItem.synced_blocks.length;
+      }
+
+      const syncEarnedReward = epochMeta.sync.per_block_reward * totalSyncedBlocksCount;
+      this.summary.epoch(epoch).set({
+        epoch,
+        val_id: v.val_id,
+        sync_earned_reward: syncEarnedReward,
+        sync_penalty: epochMeta.sync.per_block_reward * (totalBlocksToSync - totalSyncedBlocksCount),
+        sync_missed_reward: perfectSync - syncEarnedReward,
+      });
     }
   }
 }

--- a/src/duty/sync/sync.service.ts
+++ b/src/duty/sync/sync.service.ts
@@ -22,8 +22,8 @@ export class SyncService {
 
   @TrackTask('check-sync-duties')
   public async check(epoch: Epoch, stateSlot: Slot): Promise<void> {
-    this.logger.log(`Getting sync committee participation info`);
-    const SyncCommitteeBits = new BitVectorType(SYNC_COMMITTEE_SIZE); // sync participants count in committee
+    this.logger.log(`Getting sync committee participation info for state slot ${stateSlot}`);
+    const syncCommitteeBits = new BitVectorType(SYNC_COMMITTEE_SIZE); // sync participants count in committee
     const indexedValidators = await this.getSyncCommitteeIndexedValidators(epoch, stateSlot);
     this.logger.log(`Processing sync committee participation info`);
     const epochBlocks: BlockInfoResponse[] = [];
@@ -31,35 +31,69 @@ export class SyncService {
     const startSlot = epoch * this.config.get('FETCH_INTERVAL_SLOTS');
     for (let slot = startSlot; slot < startSlot + this.config.get('FETCH_INTERVAL_SLOTS'); slot = slot + 1) {
       const blockInfo = await this.clClient.getBlockInfo(slot);
-      blockInfo ? epochBlocks.push(blockInfo) : missedSlots.push(slot);
+      if (blockInfo) {
+        epochBlocks.push(blockInfo);
+      } else {
+        missedSlots.push(slot);
+      }
     }
+
     this.logger.debug(`All missed slots in getting sync committee info process: ${missedSlots}`);
+    /**
+     * @todo is it possible to have all missed slots in an epoch (and so, zero epoch blocks)?
+     */
     const epochBlocksBits = epochBlocks.map((block) => {
       return {
         block: Number(block.message.slot),
-        bits: SyncCommitteeBits.deserialize(fromHexString(block.message.body.sync_aggregate.sync_committee_bits)),
+        bits: syncCommitteeBits.deserialize(fromHexString(block.message.body.sync_aggregate.sync_committee_bits)),
       };
     });
+
     for (const indexedValidator of indexedValidators) {
-      const synced_blocks: number[] = [];
+      const syncedBlocks: number[] = [];
       for (const blockBits of epochBlocksBits) {
         if (blockBits.bits.get(indexedValidator.in_committee_index)) {
-          synced_blocks.push(blockBits.block);
+          syncedBlocks.push(blockBits.block);
         }
       }
+
       const index = Number(indexedValidator.validator_index);
-      const percent = (synced_blocks.length / epochBlocksBits.length) * 100;
-      this.summary.epoch(epoch).set({
-        epoch,
-        val_id: index,
-        is_sync: true,
-        sync_percent: percent,
-        sync_meta: {
-          synced_blocks,
-        },
-      });
+      const summaryValidator = this.summary.epoch(epoch).get(index);
+
+      if (summaryValidator.is_sync) {
+        let percentSum = 0;
+        for (const syncMetaItem of summaryValidator.sync_meta) {
+          percentSum += (syncMetaItem.synced_blocks.length / epochBlocksBits.length) * 100;
+        }
+        percentSum += (syncedBlocks.length / epochBlocksBits.length) * 100;
+
+        const newSyncMeta = [...summaryValidator.sync_meta];
+        newSyncMeta.push({
+          synced_blocks: syncedBlocks,
+        });
+
+        this.summary.epoch(epoch).set({
+          epoch,
+          val_id: index,
+          sync_percent: percentSum / (summaryValidator.sync_meta.length + 1),
+          sync_meta: newSyncMeta,
+        });
+      } else {
+        this.summary.epoch(epoch).set({
+          epoch,
+          val_id: index,
+          is_sync: true,
+          sync_percent: (syncedBlocks.length / epochBlocksBits.length) * 100,
+          sync_meta: [{ synced_blocks: syncedBlocks }],
+        });
+      }
     }
-    this.summary.epoch(epoch).setMeta({ sync: { blocks_to_sync: epochBlocksBits.map((b) => b.block) } });
+
+    this.summary.epoch(epoch).setMeta({
+      sync: {
+        blocks_to_sync: epochBlocksBits.map((b) => b.block),
+      },
+    });
   }
 
   public async getSyncCommitteeIndexedValidators(epoch: Epoch, stateId: StateId): Promise<SyncCommitteeValidator[]> {

--- a/src/duty/sync/sync.service.ts
+++ b/src/duty/sync/sync.service.ts
@@ -60,7 +60,7 @@ export class SyncService {
       const index = Number(indexedValidator.validator_index);
       const summaryValidator = this.summary.epoch(epoch).get(index);
 
-      if (summaryValidator.is_sync) {
+      if (summaryValidator?.is_sync) {
         let percentSum = 0;
         for (const syncMetaItem of summaryValidator.sync_meta) {
           percentSum += (syncMetaItem.synced_blocks.length / epochBlocksBits.length) * 100;


### PR DESCRIPTION
There was a bug in the accounting of sync committees. One validator could participate in the same sync committee multiple times under different committee indexes. Previously in the code, there was an implicit assumption that a validator can be presented in a sync committee of the particular block only one time. This led to an incorrect accounting of sync committees and incorrect calculation of validator rewards for participation in sync committees.

For example, in the 5-th Pectra devnet, the validator [8568](https://dora.pectra-devnet-5.ethpandaops.io/validator/0x9617f22db51844882a8115ee19613cf7a6211107a878aefc61111ad650304f0557aa10f977c38b9b978349c5eaf8ecc2) proposed a slot [179518](https://dora.pectra-devnet-5.ethpandaops.io/slot/179518) in the epoch [5609](https://dora.pectra-devnet-5.ethpandaops.io/epoch/5609). The sync committee for epoch 5609 contains validators with indexes 1298, 2561, 4326, 8113, and 9377 two times. Rewards for participation of these validators in the sync committee for the second time were not taken into account. So, when slot 179518 is proposed, EVM calculated rewards for proposing this slot incorrectly.

Now the bug is fixed. The `sync_meta` field of the `ValidatorDutySummary` structure was extended to contain several synced blocks if a validator participate in the same committee multiple times. Also, the calculation of the percentage of sync committee participation and the calculation of rewards for sync committee participation have been updated.