### PR TITLE
fix: missed rewards for attestations

### DIFF
--- a/src/duty/attestation/attestation.rewards.ts
+++ b/src/duty/attestation/attestation.rewards.ts
@@ -87,6 +87,15 @@ export class AttestationRewards {
       att_earned_reward = rewardSource + rewardTarget + rewardHead;
       att_missed_reward = perfectAttestationRewards - att_earned_reward;
       att_penalty = penaltySource + penaltyTarget + penaltyHead;
+
+      /**
+       * @todo @hack If max effective balance of the validator is greater than 32, don't calculate missed rewards for
+       * attestations. We need to figure out how to calculate missed rewards for validators of 0x02 type.
+       */
+      if (increments > 32 || att_missed_reward < 0) {
+        att_missed_reward = 0;
+      }
+
       // And save it to summary of current epoch
       this.summary.epoch(epoch).set({
         epoch,


### PR DESCRIPTION
The current calculation algorithm of missed rewards for attestations is working incorrectly for validators with a max effective balance greater than 32. As a result of this calculation, the value of the missed attestation reward for such validators might be negative. The attempt to store a negative value of missed attestation reward to the DB causes failures that lead to a complete inability to update the "validators_summary" table and loss of data about all validators in the epoch where this calculation error happened.

The calculation of missed attestation rewards for 0x02 validators is temporarily disabled until we understand better how to calculate missed attestation rewards for all types of validators.