### PR TITLE
fix: missed rewards for attestations - 2

### DIFF
--- a/src/duty/attestation/attestation.rewards.ts
+++ b/src/duty/attestation/attestation.rewards.ts
@@ -39,6 +39,9 @@ export class AttestationRewards {
         .toString(),
     );
 
+    // Perfect attestation (with multipliers). Need for calculating missed reward
+    const perfect = getRewards({ source: true, target: true, head: true });
+
     const maxBatchSize = 1000;
     let index = 0;
     for (const v of this.summary.epoch(epoch).values()) {
@@ -66,8 +69,6 @@ export class AttestationRewards {
       const targetParticipationBaseRewardIncrements = baseRewardIncrements * targetParticipation;
       const headParticipationBaseRewardIncrements = baseRewardIncrements * headParticipation;
 
-      // Perfect attestation (with multipliers). Need for calculating missed reward
-      const perfect = getRewards({ source: true, target: true, head: true });
       const perfectAttestationRewards =
         Math.trunc(perfect.source * sourceParticipationBaseRewardIncrements) +
         Math.trunc(perfect.target * targetParticipationBaseRewardIncrements) +


### PR DESCRIPTION
Proper fix for missed attestations rewards calculation.

In the previous version of the missed rewards calculation algorithm, there was a hard assumption that the effective balance of any validator must be 32 ETH. After Pectra hardfork this assumption is no longer valid. So, now to calculate the "perfect" attestation rewards that a validator could earn if it fully executes all attestation duties the algorithm should use the actual validator effective balance, not 32.

This PR makes the rewards calculation algorithm use the actual validator balance in missed rewards calculation and also extracts some common multiplications to new variables.