### PR TITLE
Switch to Node.js 20.x (LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.20.1-alpine AS building
+FROM node:20.19.0-alpine AS building
 
 WORKDIR /app
 
@@ -9,7 +9,7 @@ COPY ./tsconfig*.json ./
 COPY ./src ./src
 RUN yarn build
 
-FROM node:18.20.1-alpine
+FROM node:20.19.0-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.20.1-alpine as building
+FROM node:18.20.1-alpine AS building
 
 WORKDIR /app
 


### PR DESCRIPTION
Node 18 LTS support ended by March 2025, by switching to node 20 which will give 4 more years support.

![image](https://github.com/user-attachments/assets/a3e5668d-1ecd-43a7-b0ca-01f8c2f015e2)
