### PR TITLE
fix: exclude pending initialized validators

### DIFF
--- a/src/common/consensus-provider/consensus-provider.service.ts
+++ b/src/common/consensus-provider/consensus-provider.service.ts
@@ -27,7 +27,7 @@ import {
 import { BlockId, Epoch, Slot, StateId } from './types';
 
 let ssz: typeof import('@lodestar/types').ssz;
-let anySsz: typeof ssz.phase0 | typeof ssz.altair | typeof ssz.bellatrix | typeof ssz.capella | typeof ssz.deneb;
+let anySsz: typeof ssz.phase0 | typeof ssz.altair | typeof ssz.bellatrix | typeof ssz.capella | typeof ssz.deneb | typeof ssz.electra;
 let ForkName: typeof import('@lodestar/params').ForkName;
 
 interface RequestRetryOptions {

--- a/src/storage/clickhouse/clickhouse.constants.ts
+++ b/src/storage/clickhouse/clickhouse.constants.ts
@@ -611,7 +611,10 @@ export const userNodeOperatorsRewardsAndPenaltiesStats = (epoch: Epoch): string 
     FROM (
       SELECT val_nos_module_id, val_nos_id, att_earned_reward, att_missed_reward, att_penalty
       FROM validators_summary
-      WHERE val_nos_id IS NOT NULL AND val_stuck = 0 AND epoch = ${epoch} - 1
+      WHERE val_nos_id IS NOT NULL AND
+      val_stuck = 0 AND
+      val_status != '${ValStatus.PendingInitialized}' AND
+      epoch = ${epoch} - 1
       LIMIT 1 BY val_id
     )
     GROUP BY val_nos_module_id, val_nos_id
@@ -626,7 +629,11 @@ export const userNodeOperatorsRewardsAndPenaltiesStats = (epoch: Epoch): string 
     FROM (
       SELECT val_nos_module_id, val_nos_id, propose_earned_reward, propose_missed_reward, propose_penalty
       FROM validators_summary
-      WHERE val_nos_id IS NOT NULL AND val_stuck = 0 AND epoch = ${epoch} and is_proposer = 1
+      WHERE val_nos_id IS NOT NULL AND
+      val_stuck = 0 AND
+      val_status != '${ValStatus.PendingInitialized}' AND
+      epoch = ${epoch} AND
+      is_proposer = 1
       LIMIT 1 BY val_id
     )
     GROUP BY val_nos_module_id, val_nos_id
@@ -644,7 +651,11 @@ export const userNodeOperatorsRewardsAndPenaltiesStats = (epoch: Epoch): string 
     FROM (
       SELECT val_nos_module_id, val_nos_id, sync_earned_reward, sync_missed_reward, sync_penalty
       FROM validators_summary
-      WHERE val_nos_id IS NOT NULL AND val_stuck = 0 AND epoch = ${epoch} and is_sync = 1
+      WHERE val_nos_id IS NOT NULL AND
+      val_stuck = 0 AND
+      val_status != '${ValStatus.PendingInitialized}' AND
+      epoch = ${epoch} AND
+      is_sync = 1
       LIMIT 1 BY val_id
     )
     GROUP BY val_nos_module_id, val_nos_id
@@ -663,6 +674,7 @@ export const userNodeOperatorsRewardsAndPenaltiesStats = (epoch: Epoch): string 
       WHERE
         val_nos_id IS NOT NULL AND
         val_stuck = 0 AND
+        val_status != '${ValStatus.PendingInitialized}' AND
         epoch = ${epoch}
       LIMIT 1 BY val_id
     ) AS current
@@ -672,6 +684,7 @@ export const userNodeOperatorsRewardsAndPenaltiesStats = (epoch: Epoch): string 
       WHERE
         val_nos_id IS NOT NULL AND
         val_stuck = 0 AND
+        val_status != '${ValStatus.PendingInitialized}' AND
         epoch = (${epoch} - 1)
       LIMIT 1 BY val_id
     ) AS previous ON previous.val_id = current.val_id
@@ -684,6 +697,7 @@ export const userNodeOperatorsRewardsAndPenaltiesStats = (epoch: Epoch): string 
         WHERE
           val_nos_id IS NOT NULL AND
           val_status != '${ValStatus.WithdrawalDone}' AND
+          val_status != '${ValStatus.PendingInitialized}' AND
           val_balance_withdrawn > 0 AND
           val_stuck = 0 AND
           epoch = ${epoch}


### PR DESCRIPTION
Exclude validators with the "pending_initialized" status from the reward calculation.

There was an error with the reward calculation for some validators on Hoodi testnet on the epoch when the Pectra hardfork was activated (2048).

At the time of the hadrfork, many validators of the "Attestant (BVI) Limited" node operator were waiting for the activation. Most of these validators had the status "pending_queued" at the last epoch before the hardfork (2047). All validators with this status had 32 ETH on their balance. On the epoch 2048 (Pectra hardfork activation epoch), some of these validators changed their status from "pending_queued" to "pending_initialized" (for example, validators with indexes from 1073611 to 1074310) and their balance became zero.

To calculate reward calculation error EVM compares all the rewards calculated by EVM algorithms with the validators' balance change. As in the previous epoch balance of many validators was 32, and in the next epoch it became zero, it led to an incorrect reward calculation error.

To avoid this kind of issue in the future, validators with the "pending_initialized" status are now excluded from the rewards calculation. As these validators are not active anyway and don't participate in validator duties, no rewards or penalties can be applied to them.