### PR TITLE
fix: issues in test alert rules metadata strings

### DIFF
--- a/docker/prometheus/alerts_rules.test
+++ b/docker/prometheus/alerts_rules.test
@@ -24,7 +24,7 @@ tests:
             exp_annotations:
               emoji: 🔪
               summary: "Operators have slashed validators"
-              description: "Number of slashed validators per operator"
+              description: "Number of slashed validators per operator."
               field_name: "Operator 1"
               field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-660000.000000&to=540000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
@@ -38,7 +38,7 @@ tests:
             exp_annotations:
               emoji: 🔪
               summary: "Operators have slashed validators"
-              description: "Number of slashed validators per operator"
+              description: "Number of slashed validators per operator."
               field_name: "Operator 2"
               field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+2&from=-660000.000000&to=540000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
@@ -56,7 +56,7 @@ tests:
             exp_annotations:
               emoji: 🔪
               summary: "Operators have slashed validators"
-              description: "Number of slashed validators per operator"
+              description: "Number of slashed validators per operator."
               field_name: "Operator 1"
               field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-180000.000000&to=1020000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
@@ -69,7 +69,7 @@ tests:
             exp_annotations:
               emoji: 🔪
               summary: "Operators have slashed validators"
-              description: "Number of slashed validators per operator"
+              description: "Number of slashed validators per operator."
               field_name: "Operator 2"
               field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+2&from=-180000.000000&to=1020000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
@@ -85,7 +85,7 @@ tests:
             exp_annotations:
               emoji: 🔪
               summary: "Operators have slashed validators"
-              description: "Number of slashed validators per operator"
+              description: "Number of slashed validators per operator."
               field_name: "Operator 2"
               field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+2&from=300000.000000&to=1500000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
@@ -107,9 +107,9 @@ tests:
             exp_annotations:
               emoji: ⏳
               summary: "Data actuality greater then 1 hour"
-              description: "(1h 1m 40s) It's not OK. Please, check app health"
-              resolved_summary: "Data actuality is back to normal and now less then 1 hour"
-              resolved_description: "It's OK"
+              description: "It's not OK. Please, check app health."
+              resolved_summary: "Data actuality is back to normal and now less then 1 hour."
+              resolved_description: "It's OK."
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 0'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -122,8 +122,6 @@ tests:
         values: 0+0x48 1+0x48 2+0x48 0+0x48
       - series: ethereum_validators_monitoring_epoch_number
         values: 0+0x48 1+0x48 2+0x48 3+0x48 3+0x48 4+0x48
-      - series: ethereum_validators_monitoring_validator_count_with_negative_balances_delta_alert{nos_name="Operator 1"}
-        values: 0+0x48 1+0x6 0+0x41 2+0x48 0+0x48
     alert_rule_test:
       - alertname: NumValidatorsWithNegativeDelta
         eval_time: 5m
@@ -137,7 +135,7 @@ tests:
               emoji: 💸
               summary: "Operators have a negative balance delta"
               description: "Number of validators per operator who have a negative balance delta."
-              resolved_summary: "Operators have a positive balance delta"
+              resolved_summary: "Operators have a positive balance delta."
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
               field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-660000.000000&to=540000.000000)"
@@ -154,7 +152,7 @@ tests:
               emoji: 💸
               summary: "Operators have a negative balance delta"
               description: "Number of validators per operator who have a negative balance delta."
-              resolved_summary: "Operators have a positive balance delta"
+              resolved_summary: "Operators have a positive balance delta."
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
               field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-180000.000000&to=1020000.000000)"
@@ -184,7 +182,7 @@ tests:
               emoji: 📝❌
               summary: "Operators have missed attestation in last 3 finalized epochs"
               description: "Number of validators per operator who have missed attestations."
-              resolved_summary: "Operators not have missed attestation in last 3 finalized epochs"
+              resolved_summary: "Operators not have missed attestation in last 3 finalized epochs."
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
               field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-660000.000000&to=540000.000000)"
@@ -204,7 +202,7 @@ tests:
               emoji: 📝❌
               summary: "Operators have missed attestation in last 3 finalized epochs"
               description: "Number of validators per operator who have missed attestations."
-              resolved_summary: "Operators not have missed attestation in last 3 finalized epochs"
+              resolved_summary: "Operators not have missed attestation in last 3 finalized epochs."
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
               field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-180000.000000&to=1020000.000000)"
@@ -224,7 +222,7 @@ tests:
               emoji: 📝❌
               summary: "Operators have missed attestation in last 3 finalized epochs"
               description: "Number of validators per operator who have missed attestations."
-              resolved_summary: "Operators not have missed attestation in last 3 finalized epochs"
+              resolved_summary: "Operators not have missed attestation in last 3 finalized epochs."
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
               field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=300000.000000&to=1500000.000000)"
@@ -387,7 +385,7 @@ tests:
               emoji: 📥
               summary: "Operators missed block propose in the last finalized epoch"
               description: "Number of validators per operator who missed block propose."
-              resolved_summary: "Operators not missed block propose in the last finalized epoch"
+              resolved_summary: "Operators not missed block propose in the last finalized epoch."
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
               field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-660000.000000&to=540000.000000)"
@@ -406,7 +404,7 @@ tests:
               emoji: 📥
               summary: "Operators missed block propose in the last finalized epoch"
               description: "Number of validators per operator who missed block propose."
-              resolved_summary: "Operators not missed block propose in the last finalized epoch"
+              resolved_summary: "Operators not missed block propose in the last finalized epoch."
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
               field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-180000.000000&to=1020000.000000)"
@@ -425,7 +423,7 @@ tests:
               emoji: 📥
               summary: "Operators missed block propose in the last finalized epoch"
               description: "Number of validators per operator who missed block propose."
-              resolved_summary: "Operators not missed block propose in the last finalized epoch"
+              resolved_summary: "Operators not missed block propose in the last finalized epoch."
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
               field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=300000.000000&to=1500000.000000)"
@@ -457,7 +455,7 @@ tests:
               emoji: 🔄
               summary: "Operators sync participation less than average in last 3 finalized epochs"
               description: "Number of validators per operator whose sync participation less than average."
-              resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epochs"
+              resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epochs."
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
               field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-660000.000000&to=540000.000000)"
@@ -477,7 +475,7 @@ tests:
               emoji: 🔄
               summary: "Operators sync participation less than average in last 3 finalized epochs"
               description: "Number of validators per operator whose sync participation less than average."
-              resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epochs"
+              resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epochs."
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
               field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-180000.000000&to=1020000.000000)"
@@ -497,7 +495,7 @@ tests:
               emoji: 🔄
               summary: "Operators sync participation less than average in last 3 finalized epochs"
               description: "Number of validators per operator whose sync participation less than average."
-              resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epochs"
+              resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epochs."
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
               field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=300000.000000&to=1500000.000000)"
@@ -508,7 +506,6 @@ tests:
         eval_time: 33m
       - alertname: NumValidatorsWithSyncParticipationLessAvgLastNEpoch
         eval_time: 41m
-
 
   - interval: 10s
     input_series:
@@ -528,7 +525,7 @@ tests:
               epoch_interval: 3
             exp_annotations:
               emoji: 📈🔄
-              summary: "Operators may get high rewards in the future, but sync participation less than average in last 3 finalized epochs!"
+              summary: "Operators may get high rewards in the future, but sync participation less than average in last 3 finalized epochs"
               description: "Number of validators per operator whose sync participation less than average."
               resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epoch. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."
@@ -548,7 +545,7 @@ tests:
               epoch_interval: 3
             exp_annotations:
               emoji: 📈🔄
-              summary: "Operators may get high rewards in the future, but sync participation less than average in last 3 finalized epochs!"
+              summary: "Operators may get high rewards in the future, but sync participation less than average in last 3 finalized epochs"
               description: "Number of validators per operator whose sync participation less than average."
               resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epoch. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."
@@ -568,7 +565,7 @@ tests:
               epoch_interval: 3
             exp_annotations:
               emoji: 📈🔄
-              summary: "Operators may get high rewards in the future, but sync participation less than average in last 3 finalized epochs!"
+              summary: "Operators may get high rewards in the future, but sync participation less than average in last 3 finalized epochs"
               description: "Number of validators per operator whose sync participation less than average."
               resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epoch. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."
@@ -600,7 +597,7 @@ tests:
               epoch_interval: 3
             exp_annotations:
               emoji: 📈📝❌
-              summary: "Operators may get high rewards in the future, but missed attestation in last 3 finalized epochs!"
+              summary: "Operators may get high rewards in the future, but missed attestation in last 3 finalized epochs"
               description: "Number of validators per operator who have missed attestations."
               resolved_summary: "Operators not have missed attestation in last 3 finalized epochs. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."
@@ -620,7 +617,7 @@ tests:
               epoch_interval: 3
             exp_annotations:
               emoji: 📈📝❌
-              summary: "Operators may get high rewards in the future, but missed attestation in last 3 finalized epochs!"
+              summary: "Operators may get high rewards in the future, but missed attestation in last 3 finalized epochs"
               description: "Number of validators per operator who have missed attestations."
               resolved_summary: "Operators not have missed attestation in last 3 finalized epochs. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."
@@ -640,7 +637,7 @@ tests:
               epoch_interval: 3
             exp_annotations:
               emoji: 📈📝❌
-              summary: "Operators may get high rewards in the future, but missed attestation in last 3 finalized epochs!"
+              summary: "Operators may get high rewards in the future, but missed attestation in last 3 finalized epochs"
               description: "Number of validators per operator who have missed attestations."
               resolved_summary: "Operators not have missed attestation in last 3 finalized epochs. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."
@@ -671,7 +668,7 @@ tests:
               nos_name: Operator 1
             exp_annotations:
               emoji: 📈📥
-              summary: "Operators may get high rewards in the future, but missed block propose in the last finalized epoch!"
+              summary: "Operators may get high rewards in the future, but missed block propose in the last finalized epoch"
               description: "Number of validators per operator who missed block propose."
               resolved_summary: "Operators not missed block propose in the last finalized epoch. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."
@@ -690,7 +687,7 @@ tests:
               nos_name: Operator 1
             exp_annotations:
               emoji: 📈📥
-              summary: "Operators may get high rewards in the future, but missed block propose in the last finalized epoch!"
+              summary: "Operators may get high rewards in the future, but missed block propose in the last finalized epoch"
               description: "Number of validators per operator who missed block propose."
               resolved_summary: "Operators not missed block propose in the last finalized epoch. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."
@@ -709,7 +706,7 @@ tests:
               nos_name: Operator 1
             exp_annotations:
               emoji: 📈📥
-              summary: "Operators may get high rewards in the future, but missed block propose in the last finalized epoch!"
+              summary: "Operators may get high rewards in the future, but missed block propose in the last finalized epoch"
               description: "Number of validators per operator who missed block propose."
               resolved_summary: "Operators not missed block propose in the last finalized epoch. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."

--- a/docker/prometheus/alerts_rules.yml
+++ b/docker/prometheus/alerts_rules.yml
@@ -25,7 +25,7 @@ groups:
           emoji: ⏳
           summary: "Data actuality greater then 1 hour"
           resolved_summary: "Data actuality is back to normal and now less then 1 hour."
-          description: "({{ humanizeDuration $value }}) It's not OK. Please, check app health."
+          description: "It's not OK. Please, check app health."
           resolved_description: "It's OK."
           url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
           footer_text: 'Epoch • {{ with query "ethereum_validators_monitoring_epoch_number" }}{{ . | first | value | printf "%.0f" }}{{ end }}'


### PR DESCRIPTION
- Fix minor issues with mismatching strings in alert rules and their tests.

- Remove timestamp from the Data actuality alert description to make it similar to the version that is used in the Lido infra.