### PR TITLE
feat: support end of time range from the future on "Node Operators" Grafana dashboard

### DIFF
--- a/docker/grafana/provisioning/dashboards/operators.json
+++ b/docker/grafana/provisioning/dashboards/operators.json
@@ -5893,7 +5893,7 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "query_result(ethereum_validators_monitoring_user_validators)",
+        "definition": "query_result(last_over_time(ethereum_validators_monitoring_user_validators[28h]))",
         "description": "",
         "hide": 0,
         "includeAll": false,
@@ -5902,7 +5902,7 @@
         "name": "nos_name_var",
         "options": [],
         "query": {
-          "query": "query_result(ethereum_validators_monitoring_user_validators)",
+          "query": "query_result(last_over_time(ethereum_validators_monitoring_user_validators[28h]))",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -5949,7 +5949,7 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "query_result(ethereum_validators_monitoring_epoch_number)",
+        "definition": "query_result(last_over_time(ethereum_validators_monitoring_epoch_number[28h]))",
         "description": "Last epoch number",
         "hide": 2,
         "includeAll": false,
@@ -5958,7 +5958,7 @@
         "name": "epoch_number_var",
         "options": [],
         "query": {
-          "query": "query_result(ethereum_validators_monitoring_epoch_number)",
+          "query": "query_result(last_over_time(ethereum_validators_monitoring_epoch_number[28h]))",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -5977,7 +5977,7 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "query_result(ethereum_validators_monitoring_sync_participation_distance_down_from_chain_avg)",
+        "definition": "query_result(last_over_time(ethereum_validators_monitoring_sync_participation_distance_down_from_chain_avg[28h]))",
         "description": "Sync participation distance down from Blockchain average",
         "hide": 2,
         "includeAll": false,
@@ -5986,7 +5986,7 @@
         "name": "sync_participation_distance_var",
         "options": [],
         "query": {
-          "query": "query_result(ethereum_validators_monitoring_sync_participation_distance_down_from_chain_avg)",
+          "query": "query_result(last_over_time(ethereum_validators_monitoring_sync_participation_distance_down_from_chain_avg[28h]))",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -6077,7 +6077,7 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "query_result(ethereum_validators_monitoring_chain_sync_participation_avg_percent)",
+        "definition": "query_result(last_over_time(ethereum_validators_monitoring_chain_sync_participation_avg_percent[28h]))",
         "description": "Chain sync participation average value",
         "hide": 2,
         "includeAll": false,
@@ -6086,7 +6086,7 @@
         "name": "chain_sync_avg_participation",
         "options": [],
         "query": {
-          "query": "query_result(ethereum_validators_monitoring_chain_sync_participation_avg_percent)",
+          "query": "query_result(last_over_time(ethereum_validators_monitoring_chain_sync_participation_avg_percent[28h]))",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -6133,7 +6133,7 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "query_result(label_join(ethereum_validators_monitoring_user_validators{nos_name='${nos_name_var}'}, \"nos_global_index\", \";\", \"nos_module_id\", \"nos_id\"))",
+        "definition": "query_result(label_join(last_over_time(ethereum_validators_monitoring_user_validators{nos_name='${nos_name_var}'}[28h]), \"nos_global_index\", \";\", \"nos_module_id\", \"nos_id\"))",
         "description": "",
         "hide": 2,
         "includeAll": false,
@@ -6142,7 +6142,7 @@
         "name": "nos_global_index_var",
         "options": [],
         "query": {
-          "query": "query_result(label_join(ethereum_validators_monitoring_user_validators{nos_name='${nos_name_var}'}, \"nos_global_index\", \";\", \"nos_module_id\", \"nos_id\"))",
+          "query": "query_result(label_join(last_over_time(ethereum_validators_monitoring_user_validators{nos_name='${nos_name_var}'}[28h]), \"nos_global_index\", \";\", \"nos_module_id\", \"nos_id\"))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -6161,7 +6161,7 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "query_result(operators_indexes_map{main_global_index='${nos_global_index_var}'} == ${show_dvts_var})",
+        "definition": "query_result(last_over_time(operators_indexes_map{main_global_index='${nos_global_index_var}'}[28h]) == ${show_dvts_var})",
         "description": "",
         "hide": 2,
         "includeAll": false,
@@ -6170,7 +6170,7 @@
         "name": "dvt_nos_global_indexes_var",
         "options": [],
         "query": {
-          "query": "query_result(operators_indexes_map{main_global_index='${nos_global_index_var}'} == ${show_dvts_var})",
+          "query": "query_result(last_over_time(operators_indexes_map{main_global_index='${nos_global_index_var}'}[28h]) == ${show_dvts_var})",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -6189,7 +6189,7 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "query_result(ethereum_validators_monitoring_user_operators_identifies{nos_global_index=~'${nos_global_index_var}|${dvt_nos_global_indexes_var}'})",
+        "definition": "query_result(last_over_time(ethereum_validators_monitoring_user_operators_identifies{nos_global_index=~'${nos_global_index_var}|${dvt_nos_global_indexes_var}'}[28h]))",
         "description": "",
         "hide": 2,
         "includeAll": true,
@@ -6198,7 +6198,7 @@
         "name": "mapped_nos_names_var",
         "options": [],
         "query": {
-          "query": "query_result(ethereum_validators_monitoring_user_operators_identifies{nos_global_index=~'${nos_global_index_var}|${dvt_nos_global_indexes_var}'})",
+          "query": "query_result(last_over_time(ethereum_validators_monitoring_user_operators_identifies{nos_global_index=~'${nos_global_index_var}|${dvt_nos_global_indexes_var}'}[28h]))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -6219,6 +6219,6 @@
   "timezone": "",
   "title": "NodeOperators",
   "uid": "3wimU2H7h",
-  "version": 26,
+  "version": 27,
   "weekStart": ""
 }

--- a/docker/prometheus/alerts_rules.test
+++ b/docker/prometheus/alerts_rules.test
@@ -140,7 +140,7 @@ tests:
               resolved_summary: "Operators have a positive balance delta"
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
-              field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-660000.000000&to=540000.000000)"
+              field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-900000.000000&to=11340000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: "Epoch • 1"
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -157,7 +157,7 @@ tests:
               resolved_summary: "Operators have a positive balance delta"
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
-              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-180000.000000&to=1020000.000000)"
+              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-420000.000000&to=11820000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: "Epoch • 2"
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -187,7 +187,7 @@ tests:
               resolved_summary: "Operators not have missed attestation in last 3 finalized epochs"
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
-              field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-660000.000000&to=540000.000000)"
+              field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-900000.000000&to=11340000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 1'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -207,7 +207,7 @@ tests:
               resolved_summary: "Operators not have missed attestation in last 3 finalized epochs"
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
-              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-180000.000000&to=1020000.000000)"
+              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-420000.000000&to=11820000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 2'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -227,7 +227,7 @@ tests:
               resolved_summary: "Operators not have missed attestation in last 3 finalized epochs"
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
-              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=300000.000000&to=1500000.000000)"
+              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=60000.000000&to=12300000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 3'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -257,7 +257,7 @@ tests:
               summary: "Operators have attestation inc. delay greater than 2 in last 3 finalized epochs"
               description: "Number of validators per operator who have attestation with high inc. delay."
               field_name: "Operator 1"
-              field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-660000.000000&to=540000.000000)"
+              field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-900000.000000&to=11340000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 1'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -275,7 +275,7 @@ tests:
               summary: "Operators have attestation inc. delay greater than 2 in last 3 finalized epochs"
               description: "Number of validators per operator who have attestation with high inc. delay."
               field_name: "Operator 1"
-              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-180000.000000&to=1020000.000000)"
+              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-420000.000000&to=11820000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 2'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -293,7 +293,7 @@ tests:
               summary: "Operators have attestation inc. delay greater than 2 in last 3 finalized epochs"
               description: "Number of validators per operator who have attestation with high inc. delay."
               field_name: "Operator 1"
-              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=300000.000000&to=1500000.000000)"
+              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=60000.000000&to=12300000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 3'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -323,7 +323,7 @@ tests:
               summary: 'Operators have invalid attestation property in last 3 finalized epochs'
               description: 'Number of validators per operator who have invalid attestation property.'
               field_name: "Operator 1"
-              field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-660000.000000&to=540000.000000)"
+              field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-900000.000000&to=11340000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 1'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -341,7 +341,7 @@ tests:
               summary: 'Operators have invalid attestation property in last 3 finalized epochs'
               description: 'Number of validators per operator who have invalid attestation property.'
               field_name: "Operator 1"
-              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-180000.000000&to=1020000.000000)"
+              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-420000.000000&to=11820000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 2'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -359,7 +359,7 @@ tests:
               summary: 'Operators have invalid attestation property in last 3 finalized epochs'
               description: 'Number of validators per operator who have invalid attestation property.'
               field_name: "Operator 1"
-              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=300000.000000&to=1500000.000000)"
+              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=60000.000000&to=12300000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 3'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -460,7 +460,7 @@ tests:
               resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epochs"
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
-              field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-660000.000000&to=540000.000000)"
+              field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-900000.000000&to=97740000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 1'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -480,7 +480,7 @@ tests:
               resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epochs"
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
-              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-180000.000000&to=1020000.000000)"
+              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-420000.000000&to=98220000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 2'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -500,7 +500,7 @@ tests:
               resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epochs"
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
-              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=300000.000000&to=1500000.000000)"
+              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=60000.000000&to=98700000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 3'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -533,7 +533,7 @@ tests:
               resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epoch. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
-              field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-660000.000000&to=540000.000000)"
+              field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-900000.000000&to=97740000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 1'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -553,7 +553,7 @@ tests:
               resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epoch. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
-              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-180000.000000&to=1020000.000000)"
+              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-420000.000000&to=98220000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 2'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -573,7 +573,7 @@ tests:
               resolved_summary: "Operators sync participation higher or equal than average in last 3 finalized epoch. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
-              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=300000.000000&to=1500000.000000)"
+              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=60000.000000&to=98700000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 3'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -605,7 +605,7 @@ tests:
               resolved_summary: "Operators not have missed attestation in last 3 finalized epochs. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
-              field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-660000.000000&to=540000.000000)"
+              field_value: "[1](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-900000.000000&to=11340000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 1'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -625,7 +625,7 @@ tests:
               resolved_summary: "Operators not have missed attestation in last 3 finalized epochs. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
-              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-180000.000000&to=1020000.000000)"
+              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=-420000.000000&to=11820000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 2'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -645,7 +645,7 @@ tests:
               resolved_summary: "Operators not have missed attestation in last 3 finalized epochs. Now may get high rewards in the future!"
               resolved_description: "Number of validators per operator who recovered."
               field_name: "Operator 1"
-              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=300000.000000&to=1500000.000000)"
+              field_value: "[2](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var=Operator+1&from=60000.000000&to=12300000.000000)"
               url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
               footer_text: 'Epoch • 3'
               footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"

--- a/docker/prometheus/alerts_rules.yml
+++ b/docker/prometheus/alerts_rules.yml
@@ -42,7 +42,7 @@ groups:
           description: 'Number of validators per operator who have a negative balance delta.'
           resolved_description: 'Number of validators per operator who recovered.'
           field_name: '{{ $labels.nos_name }}'
-          field_value: '[{{ $value | printf "%.0f" }}](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var={{ urlquery $labels.nos_name }}&from={{ with query "(time() - 1200) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }}&to={{ with query "time() * 1000" }}{{ . | first | value | printf "%f" }}{{ end }})'
+          field_value: '[{{ $value | printf "%.0f" }}](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var={{ urlquery $labels.nos_name }}&from={{ with query "(time() - 1440) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }}&to={{ with query "(time() + 10800) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }})'
           url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
           footer_text: 'Epoch • {{ with query "ethereum_validators_monitoring_epoch_number" }}{{ . | first | value | printf "%.0f" }}{{ end }}'
           footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -58,7 +58,7 @@ groups:
           description: 'Number of validators per operator who have missed attestations.'
           resolved_description: 'Number of validators per operator who recovered.'
           field_name: '{{ $labels.nos_name }}'
-          field_value: '[{{ $value | printf "%.0f" }}](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var={{ urlquery $labels.nos_name }}&from={{ with query "(time() - 1200) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }}&to={{ with query "time() * 1000" }}{{ . | first | value | printf "%f" }}{{ end }})'
+          field_value: '[{{ $value | printf "%.0f" }}](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var={{ urlquery $labels.nos_name }}&from={{ with query "(time() - 1440) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }}&to={{ with query "(time() + 10800) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }})'
           url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
           footer_text: 'Epoch • {{ with query "ethereum_validators_monitoring_epoch_number" }}{{ . | first | value | printf "%.0f" }}{{ end }}'
           footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -72,7 +72,7 @@ groups:
           summary: 'Operators have attestation inc. delay greater than 2 in last {{ $labels.epoch_interval }} finalized epochs'
           description: 'Number of validators per operator who have attestation with high inc. delay.'
           field_name: '{{ $labels.nos_name }}'
-          field_value: '[{{ $value | printf "%.0f" }}](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var={{ urlquery $labels.nos_name }}&from={{ with query "(time() - 1200) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }}&to={{ with query "time() * 1000" }}{{ . | first | value | printf "%f" }}{{ end }})'
+          field_value: '[{{ $value | printf "%.0f" }}](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var={{ urlquery $labels.nos_name }}&from={{ with query "(time() - 1440) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }}&to={{ with query "(time() + 10800) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }})'
           url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
           footer_text: 'Epoch • {{ with query "ethereum_validators_monitoring_epoch_number" }}{{ . | first | value | printf "%.0f" }}{{ end }}'
           footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -86,7 +86,7 @@ groups:
           summary: 'Operators have invalid attestation property in last {{ $labels.epoch_interval }} finalized epochs'
           description: 'Number of validators per operator who have invalid attestation property.'
           field_name: '{{ $labels.nos_name }}'
-          field_value: '[{{ $value | printf "%.0f" }}](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var={{ urlquery $labels.nos_name }}&from={{ with query "(time() - 1200) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }}&to={{ with query "time() * 1000" }}{{ . | first | value | printf "%f" }}{{ end }})'
+          field_value: '[{{ $value | printf "%.0f" }}](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var={{ urlquery $labels.nos_name }}&from={{ with query "(time() - 1440) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }}&to={{ with query "(time() + 10800) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }})'
           url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
           footer_text: 'Epoch • {{ with query "ethereum_validators_monitoring_epoch_number" }}{{ . | first | value | printf "%.0f" }}{{ end }}'
           footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -118,7 +118,7 @@ groups:
           description: 'Number of validators per operator whose sync participation less than average.'
           resolved_description: 'Number of validators per operator who recovered.'
           field_name: '{{ $labels.nos_name }}'
-          field_value: '[{{ $value | printf "%.0f" }}](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var={{ urlquery $labels.nos_name }}&from={{ with query "(time() - 1200) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }}&to={{ with query "time() * 1000" }}{{ . | first | value | printf "%f" }}{{ end }})'
+          field_value: '[{{ $value | printf "%.0f" }}](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var={{ urlquery $labels.nos_name }}&from={{ with query "(time() - 1440) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }}&to={{ with query "(time() + 97200) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }})'
           url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
           footer_text: 'Epoch • {{ with query "ethereum_validators_monitoring_epoch_number" }}{{ . | first | value | printf "%.0f" }}{{ end }}'
           footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -134,7 +134,7 @@ groups:
           description: 'Number of validators per operator whose sync participation less than average.'
           resolved_description: 'Number of validators per operator who recovered.'
           field_name: '{{ $labels.nos_name }}'
-          field_value: '[{{ $value | printf "%.0f" }}](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var={{ urlquery $labels.nos_name }}&from={{ with query "(time() - 1200) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }}&to={{ with query "time() * 1000" }}{{ . | first | value | printf "%f" }}{{ end }})'
+          field_value: '[{{ $value | printf "%.0f" }}](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var={{ urlquery $labels.nos_name }}&from={{ with query "(time() - 1440) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }}&to={{ with query "(time() + 97200) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }})'
           url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
           footer_text: 'Epoch • {{ with query "ethereum_validators_monitoring_epoch_number" }}{{ . | first | value | printf "%.0f" }}{{ end }}'
           footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"
@@ -150,7 +150,7 @@ groups:
           description: 'Number of validators per operator who have missed attestations.'
           resolved_description: 'Number of validators per operator who recovered.'
           field_name: '{{ $labels.nos_name }}'
-          field_value: '[{{ $value | printf "%.0f" }}](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var={{ urlquery $labels.nos_name }}&from={{ with query "(time() - 1200) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }}&to={{ with query "time() * 1000" }}{{ . | first | value | printf "%f" }}{{ end }})'
+          field_value: '[{{ $value | printf "%.0f" }}](http://127.0.0.1:8082/d/3wimU2H7h/nodeoperators/?var-nos_name_var={{ urlquery $labels.nos_name }}&from={{ with query "(time() - 1440) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }}&to={{ with query "(time() + 10800) * 1000" }}{{ . | first | value | printf "%f" }}{{ end }})'
           url: "http://127.0.0.1:8082/d/HRgPmpNnz/validators"
           footer_text: 'Epoch • {{ with query "ethereum_validators_monitoring_epoch_number" }}{{ . | first | value | printf "%.0f" }}{{ end }}'
           footer_icon_url: "https://cryptologos.cc/logos/steth-steth-logo.png"


### PR DESCRIPTION
Adjust "Node Operators" Grafana dashboard variables to make the dashboard work correctly if a user selects the end of the time range from the future. In this case, the logic of the dashboard assumes that the data for the last available epoch should be used.

Adjust time ranges in alerts, make the end value of the time range for some alerts several hours after the alerting event happened.