### PR TITLE
fix: batch size of Discord alerts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,8 @@ services:
     environment:
       - WORKING_MODE=alternative
       - PORT=9094
+      - MAX_EMBEDS_LENGTH=2
+      - MAX_FIELDS_LENGTH=18
     expose:
       - 9094
     ports:


### PR DESCRIPTION
Previously if too many operators were affected by an alert and so, the size of the Discord alert was large, the `alertmanager-discord` package failed to send these large alerts because of their size.

Here the new feature of the `alertmanager-discord` package that allows users to configure the size of Discord alerts is adopted. The size of the Discord alert batch and the number of batches are set in the env variables of the `alertmanager-discord` package so that now large Discord alerts should be split into smaller pieces, so now there should not be errors in sending these pieces to the Discord webhook.