### PR TITLE
fix: better warnings in logs

### DIFF
--- a/src/common/consensus-provider/consensus-provider.service.ts
+++ b/src/common/consensus-provider/consensus-provider.service.ts
@@ -418,7 +418,7 @@ export class ConsensusProviderService {
       }
 
       if (res == null) {
-        this.logger.warn(`Error while doing CL API request. Will try to switch to another API URL. ${err.message}`);
+        this.logger.warn(`Error while doing CL API request. Will try to switch to another API URL.\n${err.message}`);
       }
     }
 

--- a/src/common/functions/retrier.ts
+++ b/src/common/functions/retrier.ts
@@ -22,12 +22,12 @@ export const retrier = (
     logWarning = logWarning ?? defaultLogWarning;
     try {
       return await callback();
-    } catch (err: any) {
+    } catch (e) {
       if (maxRetryCount <= 1 || minBackoffMs >= maxBackoffMs) {
-        throw err;
+        throw e;
       }
       if (logWarning) {
-        logger.warn(err, `Retrying after (${minBackoffMs}ms). Remaining retries [${maxRetryCount}]`);
+        logger.warn(`${e.message} \nRetrying after (${minBackoffMs}ms). Remaining retries [${maxRetryCount}]`);
       }
       await sleep(minBackoffMs);
       return await retrier(logger)(callback, maxRetryCount - 1, minBackoffMs * 2, maxBackoffMs, logWarning);

--- a/src/validators-registry/keysapi-source/keysapi-source.client.ts
+++ b/src/validators-registry/keysapi-source/keysapi-source.client.ts
@@ -128,7 +128,7 @@ export class KeysapiSourceClient {
         throw err;
       }
       if (!res) {
-        this.logger.warn(`${err.message}. Error while doing KeysAPI request. Will try to switch to another API URL`);
+        this.logger.warn(`Error while doing KeysAPI request. Will try to switch to another API URL.\n${err.message}`);
       }
     }
 


### PR DESCRIPTION
When `LOG_FORMAT` is set to "simple", the `logger.warn(error)` command logs only the non-default keys of the error object, but not the error message itself. So, in the "simple" log format it is hard to notice an important warning log, and merely impossible to determine the root cause of the error by looking only at the log message.

Now when the app needs to log an error object, the log with the "warning" level always logs the error message of this error object.