### PR TITLE
chore(docs): add instructions about how to configure TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ It can be changed by the TTL policy for Clickhouse:
 # Mainnet
 ALTER TABLE validators_summary MODIFY TTL toDateTime(1606824023 + (epoch * 32 * 12)) + INTERVAL 3 MONTH;
 
+# Hoodi
+ALTER TABLE validators_summary MODIFY TTL toDateTime(1742213400 + (epoch * 32 * 12)) + INTERVAL 3 MONTH;
+
 # Holesky
 ALTER TABLE validators_summary MODIFY TTL toDateTime(1695902400 + (epoch * 32 * 12)) + INTERVAL 3 MONTH;
-
-# Goerli
-ALTER TABLE validators_summary MODIFY TTL toDateTime(1616508000 + (epoch * 32 * 12)) + INTERVAL 3 MONTH;
 ```
 
 ## Application Env variables


### PR DESCRIPTION
Add a command to Readme that can be executed to configure TTL for the `validators_summary` table on Hoodi. Remove the similar command for Goerli from the Readme.