### PR TITLE
chore: change text in critical alerts

### DIFF
--- a/src/common/alertmanager/alerts/CriticalMissedAttestations.ts
+++ b/src/common/alertmanager/alerts/CriticalMissedAttestations.ts
@@ -59,7 +59,7 @@ export class CriticalMissedAttestations extends FullInclusionChecksAlert<NOsVali
       description: join(
         Object.entries(ruleResult).map(
           ([o, r]) =>
-            `- **${o}** ${r.missedAttCount} of ${r.activeCount} (${gweiToEth(r.missedAttBalance, 0)} ETH of ${gweiToEth(
+            `- **${o}**: ${r.missedAttCount} of ${r.activeCount} (${gweiToEth(r.missedAttBalance, 0)} ETH of ${gweiToEth(
               r.activeBalance,
               0,
             )} ETH);`,

--- a/src/common/alertmanager/alerts/CriticalMissedAttestations.ts
+++ b/src/common/alertmanager/alerts/CriticalMissedAttestations.ts
@@ -59,9 +59,10 @@ export class CriticalMissedAttestations extends FullInclusionChecksAlert<NOsVali
       description: join(
         Object.entries(ruleResult).map(
           ([o, r]) =>
-            `- **${o}** (${r.activeCount} active validators with total balance ${+gweiToEth(r.activeBalance).toFixed(2)} ETH): ${
-              r.missedAttCount
-            } validators with total balance ${+gweiToEth(r.missedAttBalance).toFixed(2)} ETH missed attestations;`,
+            `- **${o}** ${r.missedAttCount} of ${r.activeCount} (${gweiToEth(r.missedAttBalance, 0)} ETH of ${gweiToEth(
+              r.activeBalance,
+              0,
+            )} ETH);`,
         ),
         '\n',
       ),

--- a/src/common/alertmanager/alerts/CriticalNegativeDelta.ts
+++ b/src/common/alertmanager/alerts/CriticalNegativeDelta.ts
@@ -57,7 +57,7 @@ export class CriticalNegativeDelta extends FullInclusionChecksAlert<UserNOsValid
       description: join(
         Object.entries(ruleResult).map(
           ([o, r]) =>
-            `- **${o}** ${r.negDeltaCount} of ${r.activeCount} (${gweiToEth(r.negDeltaBalance, 0)} ETH of ${gweiToEth(
+            `- **${o}**: ${r.negDeltaCount} of ${r.activeCount} (${gweiToEth(r.negDeltaBalance, 0)} ETH of ${gweiToEth(
               r.activeBalance,
               0,
             )} ETH);`,

--- a/src/common/alertmanager/alerts/CriticalNegativeDelta.ts
+++ b/src/common/alertmanager/alerts/CriticalNegativeDelta.ts
@@ -57,9 +57,10 @@ export class CriticalNegativeDelta extends FullInclusionChecksAlert<UserNOsValid
       description: join(
         Object.entries(ruleResult).map(
           ([o, r]) =>
-            `- **${o}** (${r.activeCount} active validators with total balance ${+gweiToEth(r.activeBalance).toFixed(2)} ETH): ${
-              r.negDeltaCount
-            } validators with total balance ${+gweiToEth(r.negDeltaBalance).toFixed(2)} ETH have negative balance delta;`,
+            `- **${o}** ${r.negDeltaCount} of ${r.activeCount} (${gweiToEth(r.negDeltaBalance, 0)} ETH of ${gweiToEth(
+              r.activeBalance,
+              0,
+            )} ETH);`,
         ),
         '\n',
       ),

--- a/src/common/alertmanager/alerts/CriticalSlashing.ts
+++ b/src/common/alertmanager/alerts/CriticalSlashing.ts
@@ -64,9 +64,10 @@ export class CriticalSlashing extends Alert<SlashingRuleResult> {
       description: join(
         Object.entries(ruleResult).map(
           ([o, r]) =>
-            `- **${o}** (${r.activeCount} active validators with total balance ${+gweiToEth(r.activeBalance).toFixed(2)} ETH): ${
-              r.slashedCount
-            } validators with total balance ${+gweiToEth(r.slashedBalance).toFixed(2)} ETH were slashed;`,
+            `- **${o}** ${r.slashedCount} of ${r.activeCount} (${gweiToEth(r.slashedBalance, 0)} ETH of ${gweiToEth(
+              r.activeBalance,
+              0,
+            )} ETH);`,
         ),
         '\n',
       ),

--- a/src/common/alertmanager/alerts/CriticalSlashing.ts
+++ b/src/common/alertmanager/alerts/CriticalSlashing.ts
@@ -64,7 +64,7 @@ export class CriticalSlashing extends Alert<SlashingRuleResult> {
       description: join(
         Object.entries(ruleResult).map(
           ([o, r]) =>
-            `- **${o}** ${r.slashedCount} of ${r.activeCount} (${gweiToEth(r.slashedBalance, 0)} ETH of ${gweiToEth(
+            `- **${o}**: ${r.slashedCount} of ${r.activeCount} (${gweiToEth(r.slashedBalance, 0)} ETH of ${gweiToEth(
               r.activeBalance,
               0,
             )} ETH);`,


### PR DESCRIPTION
Change the text in critical alerts. Make it shorter and simpler. Also, round the value of balances to an integer.