### PR TITLE
fix: remove unnecessary override in dashboards

### DIFF
--- a/docker/grafana/provisioning/dashboards/operators.json
+++ b/docker/grafana/provisioning/dashboards/operators.json
@@ -2680,22 +2680,6 @@
           },
           {
             "matcher": {
-              "id": "byValue",
-              "options": {
-                "op": "eq",
-                "reducer": "allIsNull",
-                "value": -1
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hidden",
-                "value": true
-              }
-            ]
-          },
-          {
-            "matcher": {
               "id": "byName",
               "options": "Operator"
             },
@@ -3212,22 +3196,6 @@
           },
           {
             "matcher": {
-              "id": "byValue",
-              "options": {
-                "op": "gte",
-                "reducer": "allIsNull",
-                "value": 0
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hidden",
-                "value": true
-              }
-            ]
-          },
-          {
-            "matcher": {
               "id": "byName",
               "options": "Operator"
             },
@@ -3398,22 +3366,6 @@
                     "url": "https://beaconcha.in/slot/${__value.raw}"
                   }
                 ]
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byValue",
-              "options": {
-                "op": "gte",
-                "reducer": "allIsNull",
-                "value": 0
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hidden",
-                "value": true
               }
             ]
           },
@@ -3606,22 +3558,6 @@
           },
           {
             "matcher": {
-              "id": "byValue",
-              "options": {
-                "op": "gte",
-                "reducer": "allIsNull",
-                "value": 0
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hidden",
-                "value": true
-              }
-            ]
-          },
-          {
-            "matcher": {
               "id": "byName",
               "options": "Operator"
             },
@@ -3777,22 +3713,6 @@
           },
           {
             "matcher": {
-              "id": "byValue",
-              "options": {
-                "op": "gte",
-                "reducer": "allIsNull",
-                "value": 0
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hidden",
-                "value": true
-              }
-            ]
-          },
-          {
-            "matcher": {
               "id": "byName",
               "options": "Operator"
             },
@@ -3942,22 +3862,6 @@
               {
                 "id": "unit",
                 "value": "string"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byValue",
-              "options": {
-                "op": "gte",
-                "reducer": "allIsNull",
-                "value": 0
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hidden",
-                "value": true
               }
             ]
           },
@@ -4118,22 +4022,6 @@
           },
           {
             "matcher": {
-              "id": "byValue",
-              "options": {
-                "op": "gte",
-                "reducer": "allIsNull",
-                "value": 0
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hidden",
-                "value": true
-              }
-            ]
-          },
-          {
-            "matcher": {
               "id": "byName",
               "options": "Operator"
             },
@@ -4283,22 +4171,6 @@
               {
                 "id": "unit",
                 "value": "string"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byValue",
-              "options": {
-                "op": "gte",
-                "reducer": "allIsNull",
-                "value": 0
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hidden",
-                "value": true
               }
             ]
           },
@@ -4801,22 +4673,6 @@
               },
               {
                 "matcher": {
-                  "id": "byValue",
-                  "options": {
-                    "op": "gte",
-                    "reducer": "allIsNull",
-                    "value": 0
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hidden",
-                    "value": true
-                  }
-                ]
-              },
-              {
-                "matcher": {
                   "id": "byName",
                   "options": "Operator"
                 },
@@ -5198,22 +5054,6 @@
                         "url": "https://beaconcha.in/slot/${__value.raw}"
                       }
                     ]
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byValue",
-                  "options": {
-                    "op": "gte",
-                    "reducer": "allIsNull",
-                    "value": 0
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hidden",
-                    "value": true
                   }
                 ]
               },
@@ -5832,22 +5672,6 @@
               },
               {
                 "matcher": {
-                  "id": "byValue",
-                  "options": {
-                    "op": "gte",
-                    "reducer": "allIsNull",
-                    "value": 0
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hidden",
-                    "value": true
-                  }
-                ]
-              },
-              {
-                "matcher": {
                   "id": "byName",
                   "options": "Operator"
                 },
@@ -6239,22 +6063,6 @@
               },
               {
                 "matcher": {
-                  "id": "byValue",
-                  "options": {
-                    "op": "gte",
-                    "reducer": "allIsNull",
-                    "value": 0
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hidden",
-                    "value": true
-                  }
-                ]
-              },
-              {
-                "matcher": {
                   "id": "byName",
                   "options": "Operator"
                 },
@@ -6625,22 +6433,6 @@
                   {
                     "id": "unit",
                     "value": "string"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byValue",
-                  "options": {
-                    "op": "gte",
-                    "reducer": "allIsNull",
-                    "value": 0
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hidden",
-                    "value": true
                   }
                 ]
               },
@@ -7021,22 +6813,6 @@
               },
               {
                 "matcher": {
-                  "id": "byValue",
-                  "options": {
-                    "op": "gte",
-                    "reducer": "allIsNull",
-                    "value": 0
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hidden",
-                    "value": true
-                  }
-                ]
-              },
-              {
-                "matcher": {
                   "id": "byName",
                   "options": "Operator"
                 },
@@ -7412,22 +7188,6 @@
               },
               {
                 "matcher": {
-                  "id": "byValue",
-                  "options": {
-                    "op": "gte",
-                    "reducer": "allIsNull",
-                    "value": 0
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hidden",
-                    "value": true
-                  }
-                ]
-              },
-              {
-                "matcher": {
                   "id": "byName",
                   "options": "Operator"
                 },
@@ -7798,22 +7558,6 @@
                   {
                     "id": "unit",
                     "value": "string"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byValue",
-                  "options": {
-                    "op": "gte",
-                    "reducer": "allIsNull",
-                    "value": 0
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hidden",
-                    "value": true
                   }
                 ]
               },


### PR DESCRIPTION
Remove unnecessary "allIsNull" override from the table with the Clickhouse data source. In recent versions of Grafana, this override is working incorrectly and leads to a hidden "Operator" column in tables. Now this bug is fixed.