### PR TITLE
feat(vroom-551): parameterise ClickHouse table engine

### DIFF
--- a/.github/workflows/build_push_harbor.yaml
+++ b/.github/workflows/build_push_harbor.yaml
@@ -1,0 +1,72 @@
+name: Build and push to Harbor
+
+# The image the Kubernetes deployment runs: vroom-evm-app in helm-charts-vroom pulls
+# registry.dev.k8s-dev.org/team-vroom/ethereum-validators-monitoring:dev, and
+# argocd-image-updater rolls the Deployment when the digest behind that tag changes.
+#
+# This does not replace ci-dev.yml. That one dispatches into lidofinance/infra-mainnet,
+# which builds the Docker Hub image and runs the ansible deployment — the path production
+# still uses. Both run off `develop` for now, and the second one goes away with ansible.
+#
+# Why not point the chart at the existing Docker Hub `:dev` instead of building again: it
+# is produced by the infra-mainnet pipeline, so the Kubernetes rollout would stay coupled
+# to the deployment path the migration exists to leave. Building here makes a merge to
+# develop the whole release path.
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'src/**'
+      - 'Dockerfile'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'build-info.json'
+      - '.github/workflows/build_push_harbor.yaml'
+
+env:
+  REGISTRY: registry.dev.k8s-dev.org
+  REPOSITORY: team-vroom
+  APP: ethereum-validators-monitoring
+  IMAGE_TAG: dev
+  REGISTRY_USER: robot$team-vroom+ethereum-validators-monitoring
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-24.04
+    environment: harbor_dev_release
+    steps:
+      # Actions pinned by commit SHA rather than by tag: a tag is mutable, and this is a
+      # workflow that holds a Harbor push credential.
+      - name: Check out the repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # No test step here on purpose, unlike the equivalent workflow in
+      # keys-api-versioned: this repository already gates pull requests with checks.yml
+      # and test-e2e.yml, so anything reaching develop has been through them.
+      - name: Setup buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to Harbor
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ secrets.HARBOR_DEV_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.APP }}:${{ env.IMAGE_TAG }}
+          # `yarn install --frozen-lockfile` is the slow layer and it only changes with
+          # yarn.lock.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ ALTER TABLE validators_summary MODIFY TTL toDateTime(1695902400 + (epoch * 32 * 
 * **Required:** false
 * **Default:** 120
 ---
+`DB_CLICKHOUSE_REPLICATED` - Create Clickhouse tables with the `Replicated*` table engine family instead of the plain one.
+* **Required:** false
+* **Default:** false
+* **Note:** enable it only when the target database is backed by a replicated Clickhouse cluster. The table engine is
+  declared without arguments, so the replica path is taken from the database (`Replicated` database engine) or from the
+  server-side `default_replica_path` / `default_replica_name` defaults.
+---
 `DRY_RUN` - Run application in dry mode. This means that it runs a main cycle once every 24 hours.
 * **Required:** false
 * **Values:** true / false

--- a/src/common/config/env.validation.ts
+++ b/src/common/config/env.validation.ts
@@ -120,6 +120,14 @@ export class EnvironmentVariables {
   @Transform(({ value }) => parseInt(value, 10), { toClassOnly: true })
   public DB_MAX_BACKOFF_SEC = 120;
 
+  /**
+   * Create ClickHouse tables with the Replicated* table engine family.
+   * Enable it only when the target database is backed by a replicated cluster.
+   */
+  @IsBoolean()
+  @Transform(({ value }) => toBoolean(value), { toClassOnly: true })
+  public DB_CLICKHOUSE_REPLICATED = false;
+
   @IsNotEmpty()
   @IsInt()
   @Min(1)

--- a/src/storage/clickhouse/clickhouse.service.ts
+++ b/src/storage/clickhouse/clickhouse.service.ts
@@ -282,7 +282,12 @@ export class ClickhouseService implements OnModuleInit {
 
   public async migrate(): Promise<void> {
     this.logger.log('Running migrations');
-    const migrations = [
+    // Table engine is resolved once and applied to every table created below.
+    // The replicated variant takes no arguments on purpose: the deployment uses the `Replicated` database engine,
+    // so DDL replication is set up at the database level by the infra chart, not by this app.
+    const engine = this.config.get('DB_CLICKHOUSE_REPLICATED') ? 'ReplicatedReplacingMergeTree()' : 'ReplacingMergeTree()';
+    this.logger.log(`Using ClickHouse table engine [${engine}]`);
+    const migrations: (string | ((engine: string) => string))[] = [
       migration_000000_summary,
       migration_000001_indexes,
       migration_000002_rewards,
@@ -294,7 +299,8 @@ export class ClickhouseService implements OnModuleInit {
       migration_000008_last_not_missed_slot,
       migration_000009_pending_consolidations,
     ];
-    for (const query of migrations) {
+    for (const migration of migrations) {
+      const query = typeof migration === 'function' ? migration(engine) : migration;
       await this.db.exec({ query });
     }
   }

--- a/src/storage/clickhouse/clickhouse.service.ts
+++ b/src/storage/clickhouse/clickhouse.service.ts
@@ -283,8 +283,9 @@ export class ClickhouseService implements OnModuleInit {
   public async migrate(): Promise<void> {
     this.logger.log('Running migrations');
     // Table engine is resolved once and applied to every table created below.
-    // The replicated variant takes no arguments on purpose: the deployment uses the `Replicated` database engine,
-    // so DDL replication is set up at the database level by the infra chart, not by this app.
+    // The replicated variant is declared without arguments: the replica path then comes from the database, when it runs
+    // the `Replicated` engine, or from the server's default_replica_path / default_replica_name. Replication itself is
+    // configured outside this app.
     const engine = this.config.get('DB_CLICKHOUSE_REPLICATED') ? 'ReplicatedReplacingMergeTree()' : 'ReplacingMergeTree()';
     this.logger.log(`Using ClickHouse table engine [${engine}]`);
     const migrations: (string | ((engine: string) => string))[] = [

--- a/src/storage/clickhouse/migrations/migration_000000_summary.ts
+++ b/src/storage/clickhouse/migrations/migration_000000_summary.ts
@@ -1,4 +1,4 @@
-const sql = `
+const sql = (engine: string) => `
 CREATE TABLE IF NOT EXISTS validators_summary (
     "epoch" Int64,
     "val_id" Int64,
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS validators_summary (
     INDEX proposer_index (is_proposer) TYPE set(2) GRANULARITY 8192,
     INDEX sync_index (is_sync) TYPE set(2) GRANULARITY 8192
 )
-ENGINE = ReplacingMergeTree()
+ENGINE = ${engine}
 ORDER BY (epoch, val_id)
 PARTITION BY intDiv(epoch, 225)
 `;

--- a/src/storage/clickhouse/migrations/migration_000001_indexes.ts
+++ b/src/storage/clickhouse/migrations/migration_000001_indexes.ts
@@ -1,9 +1,9 @@
-const sql = `
+const sql = (engine: string) => `
 CREATE TABLE IF NOT EXISTS validators_index (
     "val_id" Int64,
     "val_pubkey" String
 )
-ENGINE = ReplacingMergeTree()
+ENGINE = ${engine}
 ORDER BY val_id
 `;
 export default sql;

--- a/src/storage/clickhouse/migrations/migration_000003_epoch_meta.ts
+++ b/src/storage/clickhouse/migrations/migration_000003_epoch_meta.ts
@@ -1,4 +1,4 @@
-const sql = `
+const sql = (engine: string) => `
 CREATE TABLE IF NOT EXISTS epochs_metadata (
     "epoch" Int64,
     "active_validators" UInt32,
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS epochs_metadata (
     "sync_blocks_to_sync" Array(Int64),
     INDEX epoch_index (epoch) TYPE minmax GRANULARITY 8192
 )
-ENGINE = ReplacingMergeTree()
+ENGINE = ${engine}
 ORDER BY epoch
 `;
 export default sql;

--- a/src/storage/clickhouse/migrations/migration_000004_epoch_processing.ts
+++ b/src/storage/clickhouse/migrations/migration_000004_epoch_processing.ts
@@ -1,10 +1,10 @@
-const sql = `
+const sql = (engine: string) => `
 CREATE TABLE IF NOT EXISTS epochs_processing (
     "epoch" Int64,
     "is_stored" Nullable(UInt8),
     "is_calculated" Nullable(UInt8)
 )
-ENGINE = ReplacingMergeTree()
+ENGINE = ${engine}
 ORDER BY epoch
 `;
 export default sql;

--- a/src/storage/clickhouse/migrations/migration_000009_pending_consolidations.ts
+++ b/src/storage/clickhouse/migrations/migration_000009_pending_consolidations.ts
@@ -1,10 +1,10 @@
-const sql = `
+const sql = (engine: string) => `
 CREATE TABLE IF NOT EXISTS pending_consolidations (
     "epoch" Int64,
     "source_val_id" Int64,
     "target_val_id" Int64
 )
-ENGINE = ReplacingMergeTree()
+ENGINE = ${engine}
 ORDER BY (epoch, source_val_id, target_val_id)
 `;
 export default sql;

--- a/src/storage/clickhouse/migrations/migrations.spec.ts
+++ b/src/storage/clickhouse/migrations/migrations.spec.ts
@@ -1,0 +1,150 @@
+import migration_000000_summary from './migration_000000_summary';
+import migration_000001_indexes from './migration_000001_indexes';
+import migration_000002_rewards from './migration_000002_rewards';
+import migration_000003_epoch_meta from './migration_000003_epoch_meta';
+import migration_000004_epoch_processing from './migration_000004_epoch_processing';
+import migration_000005_withdrawals from './migration_000005_withdrawals';
+import migration_000006_stuck_validators from './migration_000006_stuck_validators';
+import migration_000007_module_id from './migration_000007_module_id';
+import migration_000008_last_not_missed_slot from './migration_000008_last_not_missed_slot';
+import migration_000009_pending_consolidations from './migration_000009_pending_consolidations';
+
+const PLAIN_ENGINE = 'ReplacingMergeTree()';
+const REPLICATED_ENGINE = 'ReplicatedReplacingMergeTree()';
+
+const builders: Record<string, (engine: string) => string> = {
+  migration_000000_summary,
+  migration_000001_indexes,
+  migration_000003_epoch_meta,
+  migration_000004_epoch_processing,
+  migration_000009_pending_consolidations,
+};
+
+const plainMigrations: Record<string, string> = {
+  migration_000002_rewards,
+  migration_000005_withdrawals,
+  migration_000006_stuck_validators,
+  migration_000007_module_id,
+  migration_000008_last_not_missed_slot,
+};
+
+/**
+ * Verbatim SQL of every engine-parameterized migration, as it was before the engine became configurable.
+ * These fixtures pin the default (non-replicated) output byte for byte.
+ */
+const expectedPlainSql: Record<string, string> = {
+  migration_000000_summary: `
+CREATE TABLE IF NOT EXISTS validators_summary (
+    "epoch" Int64,
+    "val_id" Int64,
+    "val_nos_id" Nullable(UInt32),
+    "val_nos_name" Nullable(String),
+    "val_slashed" UInt8,
+    "val_status" String,
+    "val_balance" Int64,
+    "is_proposer" UInt8,
+    "block_to_propose" Nullable(Int64),
+    "block_proposed" Nullable(UInt8),
+    "is_sync" UInt8,
+    "sync_percent" Nullable(Float32),
+    "att_happened" Nullable(UInt8),
+    "att_inc_delay" Nullable(UInt8),
+    "att_valid_head" Nullable(UInt8),
+    "att_valid_target" Nullable(UInt8),
+    "att_valid_source" Nullable(UInt8),
+    INDEX epoch_index (epoch) TYPE minmax GRANULARITY 8192,
+    INDEX nos_id_index (val_nos_id) TYPE set(0) GRANULARITY 8192,
+    INDEX nos_name_index (val_nos_name) TYPE set(0) GRANULARITY 8192,
+    INDEX status_index (val_status) TYPE set(9) GRANULARITY 8192,
+    INDEX delay_index (att_inc_delay) TYPE minmax GRANULARITY 8192,
+    INDEX att_index (att_happened) TYPE set(2) GRANULARITY 8192,
+    INDEX proposer_index (is_proposer) TYPE set(2) GRANULARITY 8192,
+    INDEX sync_index (is_sync) TYPE set(2) GRANULARITY 8192
+)
+ENGINE = ReplacingMergeTree()
+ORDER BY (epoch, val_id)
+PARTITION BY intDiv(epoch, 225)
+`,
+  migration_000001_indexes: `
+CREATE TABLE IF NOT EXISTS validators_index (
+    "val_id" Int64,
+    "val_pubkey" String
+)
+ENGINE = ReplacingMergeTree()
+ORDER BY val_id
+`,
+  migration_000003_epoch_meta: `
+CREATE TABLE IF NOT EXISTS epochs_metadata (
+    "epoch" Int64,
+    "active_validators" UInt32,
+    "active_validators_total_increments" Int64,
+    "base_reward" UInt32,
+    "att_blocks_rewards" Array(Array(Int64)),
+    "att_source_participation" Int64,
+    "att_target_participation" Int64,
+    "att_head_participation" Int64,
+    "sync_blocks_rewards" Array(Array(Int64)),
+    "sync_blocks_to_sync" Array(Int64),
+    INDEX epoch_index (epoch) TYPE minmax GRANULARITY 8192
+)
+ENGINE = ReplacingMergeTree()
+ORDER BY epoch
+`,
+  migration_000004_epoch_processing: `
+CREATE TABLE IF NOT EXISTS epochs_processing (
+    "epoch" Int64,
+    "is_stored" Nullable(UInt8),
+    "is_calculated" Nullable(UInt8)
+)
+ENGINE = ReplacingMergeTree()
+ORDER BY epoch
+`,
+  migration_000009_pending_consolidations: `
+CREATE TABLE IF NOT EXISTS pending_consolidations (
+    "epoch" Int64,
+    "source_val_id" Int64,
+    "target_val_id" Int64
+)
+ENGINE = ReplacingMergeTree()
+ORDER BY (epoch, source_val_id, target_val_id)
+`,
+};
+
+const structuralClausesOf = (sql: string): string[] =>
+  sql
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => /^(ORDER BY|PARTITION BY|INDEX |TTL )/.test(line));
+
+describe('clickhouse migrations', () => {
+  describe('default (non-replicated) engine', () => {
+    it.each(Object.keys(builders))('%s reproduces the original SQL byte for byte', (name) => {
+      expect(builders[name](PLAIN_ENGINE)).toBe(expectedPlainSql[name]);
+    });
+  });
+
+  describe('replicated engine', () => {
+    it.each(Object.keys(builders))('%s uses ReplicatedReplacingMergeTree()', (name) => {
+      const sql = builders[name](REPLICATED_ENGINE);
+
+      expect(sql).toContain(`ENGINE = ${REPLICATED_ENGINE}`);
+      expect(sql).not.toContain(`ENGINE = ${PLAIN_ENGINE}`);
+    });
+
+    it.each(Object.keys(builders))('%s differs from the default output only in the engine clause', (name) => {
+      const sql = builders[name](REPLICATED_ENGINE);
+
+      expect(sql.replace(`ENGINE = ${REPLICATED_ENGINE}`, `ENGINE = ${PLAIN_ENGINE}`)).toBe(expectedPlainSql[name]);
+    });
+
+    it.each(Object.keys(builders))('%s keeps ORDER BY / PARTITION BY / INDEX definitions intact', (name) => {
+      expect(structuralClausesOf(builders[name](REPLICATED_ENGINE))).toEqual(structuralClausesOf(expectedPlainSql[name]));
+    });
+  });
+
+  describe('ALTER-only migrations', () => {
+    it.each(Object.keys(plainMigrations))('%s stays a plain string', (name) => {
+      expect(typeof plainMigrations[name]).toBe('string');
+    });
+  });
+});


### PR DESCRIPTION
Two changes the Kubernetes deployment needs, both no-ops for the current one.

## 1. `DB_CLICKHOUSE_REPLICATED` — the table engine becomes a setting

The migrations hard-coded `ENGINE = ReplacingMergeTree()`. On a replicated cluster that engine writes to one node and nothing carries the data to the other, so the replica is a database with a schema and no rows. Five of the ten migrations — the ones that `CREATE TABLE` — now take the engine as an argument; the other five are `ALTER`-only and stay plain strings.

`DB_CLICKHOUSE_REPLICATED=false` by default, so nothing changes for the deployment on the VMs.

The replicated variant is declared **without arguments**: `ReplicatedReplacingMergeTree()`. The replica path comes from the `Replicated` database engine, which the infra chart sets up at the database level — DDL replication is not this application's business. Spelling the ZooKeeper path here would move a piece of cluster topology into the app, and `ON CLUSTER` is the fallback if the database engine ever turns out not to be an option.

### Tests

`migrations.spec.ts`, 25 cases over the five parameterised migrations:

- each reproduces its original SQL **byte for byte** when given the plain engine, against fixtures copied verbatim from before the change. This is what makes "no behaviour change by default" checkable rather than asserted.
- with the replicated engine, the output differs from the default in the engine clause and nowhere else.
- `ORDER BY`, `PARTITION BY` and every `INDEX` definition survive both variants — a replicated table with a different sort key is a different table.
- the five `ALTER`-only migrations are still plain strings, so a later edit that turns one into a builder without registering it fails here.

### Operational note for reviewers

Turning this on does not by itself make the application replica-safe, and it is not meant to. `epochs_processing` is updated with `ALTER … UPDATE`, and a mutation is asynchronous on a replica: a read that follows the write can legitimately return the old row. So the application stays pinned to the primary — read-your-write does not survive being balanced across replicas — and the replica exists for Grafana, NOM self-serve and the oracle team. The Helm charts wire it that way; this flag only decides what the tables are made of.

## 2. Harbor CI

`build_push_harbor.yaml`: merge to `develop` builds and pushes `registry.dev.k8s-dev.org/team-vroom/ethereum-validators-monitoring:dev`, and `argocd-image-updater` rolls the Deployment when the digest behind that tag changes. The updater's strategy is `digest`, so a mutable `:dev` is correct here and distinguishable tags are not needed.

This does **not** replace `ci-dev.yml`. That one dispatches into `lidofinance/infra-mainnet`, which builds the Docker Hub image and runs the ansible deployment — the path production still uses. Both run off `develop` for now; the second goes away with ansible.

Pointing the chart at the existing Docker Hub `:dev` would have avoided a second build, and was rejected for one reason: that image is produced by the infra-mainnet pipeline, so the Kubernetes rollout would stay coupled to the deployment path this migration exists to leave. Building here makes a merge to `develop` the whole release path.

Actions are pinned by commit SHA rather than by tag — a tag is mutable and this workflow holds a Harbor push credential. The robot account and the `harbor_dev_release` environment secret already exist.

## Merge order

`lidofinance/helm-charts-vroom#9` registers `vroom-evm-app` on the dev cluster and expects this image. Until this lands, `argocd-image-updater` finds nothing for it and that Application waits — no other chart is affected.
