### PR TITLE
Mask Keys API source URLs and Alertmanager URL in logs

### DIFF
--- a/src/common/config/config.service.ts
+++ b/src/common/config/config.service.ts
@@ -9,7 +9,15 @@ export class ConfigService extends ConfigServiceSource<EnvironmentVariables> {
    * List of env variables that should be hidden
    */
   public get secrets(): string[] {
-    return [...this.get('EL_RPC_URLS'), ...this.get('CL_API_URLS'), this.get('DB_PASSWORD')].filter((v) => v).map((v) => String(v));
+    return [
+      ...this.get('EL_RPC_URLS'),
+      ...this.get('CL_API_URLS'),
+      ...this.get('VALIDATOR_REGISTRY_KEYSAPI_SOURCE_URLS'),
+      this.get('CRITICAL_ALERTS_ALERTMANAGER_URL'),
+      this.get('DB_PASSWORD'),
+    ]
+      .filter((v) => v)
+      .map((v) => String(v));
   }
 
   public get<T extends keyof EnvironmentVariables>(key: T): EnvironmentVariables[T] {


### PR DESCRIPTION
## What

The log transport replaces every value from `ConfigService.secrets` with `<removed>`, but the list only covered `EL_RPC_URLS`, `CL_API_URLS` and `DB_PASSWORD`. `VALIDATOR_REGISTRY_KEYSAPI_SOURCE_URLS` (may carry an API key in the path) and `CRITICAL_ALERTS_ALERTMANAGER_URL` (may carry basic-auth credentials) went through unmasked whenever a raw error object reached the logger.

## Why

Same finding class the codebase-inventory QA pass flagged on the consolidation repos: a provider URL with the key in the path reaching the log in full. The error paths that format these URLs reduce them to hostname already — the value-based replacer is the safety net for the raw throws, and its list should cover every credentialed URL the config holds.